### PR TITLE
Backport of JDK-8213713 Minor issues during MetaspaceShared::initialize_runtime_shared_and_meta_spaces

### DIFF
--- a/src/hotspot/share/memory/filemap.cpp
+++ b/src/hotspot/share/memory/filemap.cpp
@@ -292,6 +292,12 @@ bool SharedClassPathEntry::validate(bool is_class_path) {
                                  " the shared archive file: %s", name);
     }
   }
+
+  if (PrintSharedArchiveAndExit && !ok) {
+    // If PrintSharedArchiveAndExit is enabled, don't report failure to the
+    // caller. Please see above comments for more details.
+    ok = true;
+  }
   return ok;
 }
 
@@ -484,16 +490,17 @@ bool FileMapInfo::validate_shared_path_table() {
     if (i < module_paths_start_index) {
       if (shared_path(i)->validate()) {
         log_info(class, path)("ok");
+      } else {
+        assert(!UseSharedSpaces, "UseSharedSpaces should be disabled");
+        return false;
       }
     } else if (i >= module_paths_start_index) {
       if (shared_path(i)->validate(false /* not a class path entry */)) {
         log_info(class, path)("ok");
+      } else {
+        assert(!UseSharedSpaces, "UseSharedSpaces should be disabled");
+        return false;
       }
-    } else if (!PrintSharedArchiveAndExit) {
-      _validating_shared_path_table = false;
-      _shared_path_table = NULL;
-      _shared_path_table_size = 0;
-      return false;
     }
   }
 

--- a/src/hotspot/share/memory/metaspaceShared.cpp
+++ b/src/hotspot/share/memory/metaspaceShared.cpp
@@ -2095,6 +2095,7 @@ bool MetaspaceShared::map_shared_spaces(FileMapInfo* mapinfo) {
     assert(ro_top == md_base, "must be");
     assert(md_top == od_base, "must be");
 
+    _core_spaces_size = mapinfo->core_spaces_size();
     MetaspaceObj::set_shared_metaspace_range((void*)mc_base, (void*)od_top);
     return true;
   } else {
@@ -2127,7 +2128,8 @@ void MetaspaceShared::initialize_shared_spaces() {
   FileMapInfo *mapinfo = FileMapInfo::current_info();
   _cds_i2i_entry_code_buffers = mapinfo->cds_i2i_entry_code_buffers();
   _cds_i2i_entry_code_buffers_size = mapinfo->cds_i2i_entry_code_buffers_size();
-  _core_spaces_size = mapinfo->core_spaces_size();
+  // _core_spaces_size is loaded from the shared archive immediatelly after mapping
+  assert(_core_spaces_size == mapinfo->core_spaces_size(), "sanity");
   char* buffer = mapinfo->misc_data_patching_start();
   clone_cpp_vtables((intptr_t*)buffer);
 

--- a/src/hotspot/share/memory/metaspaceShared.hpp
+++ b/src/hotspot/share/memory/metaspaceShared.hpp
@@ -148,6 +148,8 @@ class MetaspaceShared : AllStatic {
   }
   static void commit_shared_space_to(char* newtop) NOT_CDS_RETURN;
   static size_t core_spaces_size() {
+    assert(DumpSharedSpaces || UseSharedSpaces, "sanity");
+    assert(_core_spaces_size != 0, "sanity");
     return _core_spaces_size;
   }
   static void initialize_dumptime_shared_and_meta_spaces() NOT_CDS_RETURN;


### PR DESCRIPTION
Please help review this backport. This is part of the necessary backports for future pre-initialization work.

Backport of JDK-8213713: Minor issues during MetaspaceShared::initialize_runtime_shared_and_meta_spaces. The issue appears to cause runtime overhead in some cases, it applies cleanly without any conflicts.