### PR TITLE
Backport of JDK-8231895: Avoid String allocations in JVM_FindLoadedClass

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -194,7 +194,6 @@ class java_lang_String : AllStatic {
 
   // Conversion between '.' and '/' formats
   static Handle externalize_classname(Handle java_string, TRAPS) { return char_converter(java_string, '/', '.', THREAD); }
-  static Handle internalize_classname(Handle java_string, TRAPS) { return char_converter(java_string, '.', '/', THREAD); }
 
   // Conversion
   static Symbol* as_symbol(oop java_string, TRAPS);

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -964,13 +964,21 @@ JVM_ENTRY(jclass, JVM_FindLoadedClass(JNIEnv *env, jobject loader, jstring name)
   ResourceMark rm(THREAD);
 
   Handle h_name (THREAD, JNIHandles::resolve_non_null(name));
-  Handle string = java_lang_String::internalize_classname(h_name, CHECK_NULL);
+  char* str = java_lang_String::as_utf8_string(h_name());
 
-  const char* str   = java_lang_String::as_utf8_string(string());
   // Sanity check, don't expect null
   if (str == NULL) return NULL;
 
-  const int str_len = (int)strlen(str);
+  // Internalize the string, converting '.' to '/' in string.
+  char* p = (char*)str;
+  while (*p != '\0') {
+      if (*p == '.') {
+          *p = '/';
+      }
+      p++;
+  }
+
+  const int str_len = (int)(p - str);
   if (str_len > Symbol::max_length()) {
     // It's impossible to create this class;  the name cannot fit
     // into the constant pool.


### PR DESCRIPTION
Hi all,

Please help review this trivial backport.

Original issue: https://bugs.openjdk.java.net/browse/JDK-8231895
HG webrev: https://hg.openjdk.java.net/jdk/jdk/rev/ccbb5a2bf3ab
Review efforts: XS

This backport applies cleanly without any conflicts.

Thanks,
Yang