### PR TITLE
Backport of JDK-8213898: CDS dumping of springboot asserts in G1ArchiveAllocator::alloc_new_region

### DIFF
--- a/src/hotspot/share/gc/g1/heapRegionManager.cpp
+++ b/src/hotspot/share/gc/g1/heapRegionManager.cpp
@@ -286,7 +286,7 @@ uint HeapRegionManager::find_highest_free(bool* expanded) {
   uint curr = max_length() - 1;
   while (true) {
     HeapRegion *hr = _regions.get_by_index(curr);
-    if (hr == NULL) {
+    if (hr == NULL || !is_available(curr)) {
       uint res = expand_at(curr, 1, NULL);
       if (res == 1) {
         *expanded = true;


### PR DESCRIPTION
Hi all,

Please help review this trivial backport.

Original issue: https://bugs.openjdk.java.net/browse/JDK-8213898
HG webrev: http://hg.openjdk.java.net/jdk/jdk/rev/4d8a023c2a03
Review efforts: XS

This backport applies cleanly without any conflicts.

Thanks,
Yang