### PR TITLE
Backport of JDK-8213563: appcds/sharedStrings/SharedStringsStress.java fails with 'GC triggered before VM initialization completed' error

### DIFF
--- a/src/hotspot/share/memory/metaspaceShared.cpp
+++ b/src/hotspot/share/memory/metaspaceShared.cpp
@@ -339,12 +339,6 @@ void MetaspaceShared::post_initialize(TRAPS) {
       ClassLoaderExt::init_app_module_paths_start_index(header->_app_module_paths_start_index);
     }
   }
-
-  if (DumpSharedSpaces) {
-    if (SharedArchiveConfigFile) {
-      read_extra_data(SharedArchiveConfigFile, THREAD);
-    }
-  }
 }
 
 void MetaspaceShared::read_extra_data(const char* filename, TRAPS) {
@@ -1701,6 +1695,12 @@ void MetaspaceShared::preload_and_dump(TRAPS) {
     tty->print_cr("Loading classes to share: done.");
 
     log_info(cds)("Shared spaces: preloaded %d classes", class_count);
+
+    if (SharedArchiveConfigFile) {
+      tty->print_cr("Reading extra data from %s ...", SharedArchiveConfigFile);
+      read_extra_data(SharedArchiveConfigFile, THREAD);
+    }
+    tty->print_cr("Reading extra data: done.");
 
     // Rewrite and link classes
     tty->print_cr("Rewriting and linking classes ...");


### PR DESCRIPTION
Hi all,

Please help review this trivial backport.

Original issue: https://bugs.openjdk.java.net/browse/JDK-8213563
HG webrev: http://hg.openjdk.java.net/jdk/jdk/rev/7d3b82b338f7
Review efforts: XS

This backport applies cleanly without any conflicts.

Thanks,
Yang