### PR TITLE
Backport of JDK-8221621 FindTests.gmk cannot handle "=" in TEST.groups comme

### DIFF
--- a/make/common/FindTests.gmk
+++ b/make/common/FindTests.gmk
@@ -53,6 +53,7 @@ define FindJtregGroupsBody
         -e 's/^groups\w*=//p' $1/TEST.ROOT)
     $1_JTREG_GROUP_FILES := $$(addprefix $1/, $$($1_JTREG_GROUP_FILENAMES))
     $1_JTREG_TEST_GROUPS := $$(strip $$(shell $$(SED) -n \
+        -e 's/^\#.*//g' \
         -e 's/\([^ ]*\)\w*=.*/\1/gp' $$(wildcard $$($1_JTREG_GROUP_FILES)) \
         | $$(SORT) -u))
   endif


### PR DESCRIPTION
Hi all,

Please help review this trivial backport.

Original issue: https://bugs.openjdk.java.net/browse/JDK-8221621
HG webrev: http://hg.openjdk.java.net/jdk/jdk/rev/f1548abd4ae0
Review efforts: XS

This backport applies cleanly without any conflicts.

Thanks,
Yang