### PR TITLE
Backport JDK-8213439: Run class initialization for boot loader classes with registered subgraph archiving entry field during CDS dump time

### DIFF
--- a/src/hotspot/share/memory/heapShared.cpp
+++ b/src/hotspot/share/memory/heapShared.cpp
@@ -883,6 +883,10 @@ void HeapShared::init_subgraph_entry_fields(ArchivableStaticFieldInfo fields[],
     Klass* k = SystemDictionary::resolve_or_null(klass_name, THREAD);
     assert(k != NULL && !HAS_PENDING_EXCEPTION, "class must exist");
     InstanceKlass* ik = InstanceKlass::cast(k);
+    assert(InstanceKlass::cast(ik)->is_shared_boot_class(),
+           "Only support boot classes");
+    ik->initialize(THREAD);
+    guarantee(!HAS_PENDING_EXCEPTION, "exception in initialize");
 
     ArchivableStaticFieldFinder finder(ik, field_name);
     ik->do_local_static_fields(&finder);

--- a/src/hotspot/share/memory/metaspaceShared.cpp
+++ b/src/hotspot/share/memory/metaspaceShared.cpp
@@ -1715,6 +1715,8 @@ void MetaspaceShared::preload_and_dump(TRAPS) {
     }
     tty->print_cr("Reading extra data: done.");
 
+    HeapShared::init_subgraph_entry_fields(THREAD);
+
     // Rewrite and link classes
     tty->print_cr("Rewriting and linking classes ...");
 
@@ -1733,7 +1735,6 @@ void MetaspaceShared::preload_and_dump(TRAPS) {
     }
 
     SystemDictionary::clear_invoke_method_table();
-    HeapShared::init_subgraph_entry_fields(THREAD);
 
     SystemDictionaryShared::finalize_verification_constraints();
 


### PR DESCRIPTION
Backport JDK-8213439: Run class initialization for boot loader classes with registered subgraph archiving entry field during CDS dump time.

Link to the openjdk changeset: http://hg.openjdk.java.net/jdk/jdk/rev/3e0ebf913679. This allows more object graphs being archived.

Patch applied cleanly.

(This backport resolved the NULL '_cache' issue encountered by JDK-8213033 backport. To avoid potential issues, looks like it's better to completely replicate all backports that I've done in this area, instead of only the main ones. I'll start pull in the remaining ones.)