### PR TITLE
Set state to 'linked' after an archived class is restored at runtime.

### DIFF
--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -1036,6 +1036,11 @@ InstanceKlass* SystemDictionary::parse_stream(Symbol* class_name,
     if (class_load_start_event.should_commit()) {
       post_class_load_event(&class_load_start_event, k, loader_data);
     }
+    if (k->is_shared() && k->is_linked()) {
+      if (JvmtiExport::should_post_class_prepare()) {
+        JvmtiExport::post_class_prepare((JavaThread *)THREAD, k);
+      }
+    }
   }
   assert(host_klass != NULL || NULL == cp_patches,
          "cp_patches only found with host_klass");
@@ -1628,6 +1633,11 @@ void SystemDictionary::define_instance_class(InstanceKlass* k, TRAPS) {
 
   }
   post_class_define_event(k, loader_data);
+  if (k->is_shared() && k->is_linked()) {
+    if (JvmtiExport::should_post_class_prepare()) {
+      JvmtiExport::post_class_prepare((JavaThread *)THREAD, k);
+    }
+  }
 }
 
 // Support parallel classloading

--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -779,18 +779,16 @@ bool SystemDictionaryShared::add_verification_constraint(Klass* k, Symbol* name,
     guarantee(strstr(k->name()->as_C_string(), "Lambda$") != NULL,
               "class should be in dictionary before being verified");
     return true;
-  }
-  entry->add_verification_constraint(name, from_name, from_field_is_protected,
-                                     from_is_array, from_is_object);
-  if (entry->is_builtin()) {
+  } else if (entry->is_builtin()) {
     // For builtin class loaders, we can try to complete the verification check at dump time,
     // because we can resolve all the constraint classes.
     return false;
-  } else {
-    // For non-builtin class loaders, we cannot complete the verification check at dump time,
-    // because at dump time we don't know how to resolve classes for such loaders.
-    return true;
   }
+  entry->add_verification_constraint(name, from_name, from_field_is_protected,
+                                     from_is_array, from_is_object);
+  // For non-builtin class loaders, we cannot complete the verification check at dump time,
+  // because at dump time we don't know how to resolve classes for such loaders.
+  return true;
 }
 
 void SystemDictionaryShared::finalize_verification_constraints_for(InstanceKlass* k) {

--- a/src/hotspot/share/classfile/verifier.hpp
+++ b/src/hotspot/share/classfile/verifier.hpp
@@ -53,6 +53,12 @@ class Verifier : AllStatic {
   static void log_end_verification(outputStream* st, const char* klassName, Symbol* exception_name, TRAPS);
   static bool verify(InstanceKlass* klass, Mode mode, bool should_verify_class, TRAPS);
 
+  static bool verify_disabled() {
+    // Check if verification is disabled for all JDK and application classes
+    // (-Xverify:none).
+    return !BytecodeVerificationLocal && !BytecodeVerificationRemote;
+  }
+
   // Return false if the class is loaded by the bootstrap loader,
   // or if defineClass was called requesting skipping verification
   // -Xverify:all/none override this value


### PR DESCRIPTION
Set state to 'linked' after an archived class is restored at runtime.

Re-initialize the itable and vtable during restoration for an archived class loaded by the non-NULL loader.

We can safely set archived classes for builtin loaders in 'linked' state at the end of restoration. If the current runtime verification mode is -Xverify:none, then no additional verification is necessary after restoration, all archived classes (including the classes loaded by user defined class loaders) can be set in 'linked' state after restoration. As a result, we save the work for iterating the super types in InstanceKlass::link_class_impl() in those cases. This saves >1.5M instructions execution during running HelloWorld.

Previously, there was also an overhead caused by trying to link methods twice (once during restore time and once during linking time) for an archived class.

Fixed SystemDictionaryShared::add_verification_constraint() to not add constraints to the archive if the current class' loader is one of the builtin loader. For classes loaded by the builtin loaders, constraints check is done at dump time.

Related OpenJDK bug is JDK-8232222.

Original change made Oct, 2019. Authored by: jianglizhou@google.com. Reviewed by:
- aeubanks@google.com
- dthomson@google.com
- rasbold@google.com

This Google patch is applied as a dependency for the general pre-init core mechanism patch, which moves the link state setting for archived classes.