### PR TITLE
Improve CDS creation using parallel operations

### DIFF
--- a/make/hotspot/symbols/symbols-shared
+++ b/make/hotspot/symbols/symbols-shared
@@ -33,3 +33,5 @@ JNI_GetDefaultJavaVMInitArgs
 JVM_FindClassFromBootLoader
 JVM_GetVersionInfo
 JVM_InitAgentProperties
+
+JVM_PreprocessClassAtDumpTime

--- a/src/hotspot/os_cpu/linux_x86/atomic_linux_x86.hpp
+++ b/src/hotspot/os_cpu/linux_x86/atomic_linux_x86.hpp
@@ -78,6 +78,20 @@ inline T Atomic::PlatformCmpxchg<1>::operator()(T exchange_value,
 
 template<>
 template<typename T>
+inline T Atomic::PlatformCmpxchg<2>::operator()(T exchange_value,
+                                                T volatile* dest,
+                                                T compare_value,
+                                                atomic_memory_order /* order */) const {
+  STATIC_ASSERT(2 == sizeof(T));
+  __asm__ volatile ("lock cmpxchgw %1,(%3)"
+                    : "=a" (exchange_value)
+                    : "r" (exchange_value), "a" (compare_value), "r" (dest)
+                    : "cc", "memory");
+  return exchange_value;
+}
+
+template<>
+template<typename T>
 inline T Atomic::PlatformCmpxchg<4>::operator()(T exchange_value,
                                                 T volatile* dest,
                                                 T compare_value,

--- a/src/hotspot/share/classfile/dictionary.cpp
+++ b/src/hotspot/share/classfile/dictionary.cpp
@@ -217,7 +217,7 @@ void Dictionary::remove_classes_in_error_state() {
     for (DictionaryEntry** p = bucket_addr(index); *p != NULL; ) {
       probe = *p;
       InstanceKlass* ik = probe->instance_klass();
-      if (ik->is_in_error_state()) { // purge this entry
+      if (ik->is_in_error_state_and_not_archived()) { // purge this entry
         *p = probe->next();
         free_entry(probe);
         ResourceMark rm;

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -130,6 +130,8 @@
   template(jdk_internal_loader_ClassLoaders_AppClassLoader,      "jdk/internal/loader/ClassLoaders$AppClassLoader")      \
   template(jdk_internal_loader_ClassLoaders_PlatformClassLoader, "jdk/internal/loader/ClassLoaders$PlatformClassLoader") \
                                                                                                   \
+  template(jdk_internal_vm_CDSParallelPreProcessor,   "jdk/internal/vm/CDSParallelPreProcessor")  \
+                                                                                                  \
   /* Java runtime version access */                                                               \
   template(java_lang_VersionProps,                    "java/lang/VersionProps")                   \
   template(java_runtime_name_name,                    "java_runtime_name")                        \
@@ -430,6 +432,8 @@
   template(vmdependencies_name,                       "vmdependencies")                           \
   template(loader_name,                               "loader")                                   \
   template(getModule_name,                            "getModule")                                \
+  template(preLoadAndProcess_name,                    "preLoadAndProcess")                        \
+  template(preLoadAndProcess_method_signature,        "(Ljava/lang/String;I)I")                   \
   template(input_stream_void_signature,               "(Ljava/io/InputStream;)V")                 \
   template(input_stream_signature,                    "Ljava/io/InputStream;")                    \
   template(print_stream_signature,                    "Ljava/io/PrintStream;")                    \

--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -68,6 +68,10 @@ extern "C" {
 JNIEXPORT jint JNICALL
 JVM_GetInterfaceVersion(void);
 
+// CDS archiving support.
+JNIEXPORT void JNICALL
+JVM_PreprocessClassAtDumpTime(JNIEnv *env, jclass k);
+
 /*************************************************************************
  PART 1: Functions for Native Libraries
  ************************************************************************/

--- a/src/hotspot/share/memory/metaspaceShared.hpp
+++ b/src/hotspot/share/memory/metaspaceShared.hpp
@@ -61,6 +61,9 @@ class MetaspaceShared : AllStatic {
   static address _cds_i2i_entry_code_buffers;
   static size_t  _cds_i2i_entry_code_buffers_size;
   static size_t  _core_spaces_size;
+
+  static bool _is_in_parallel_phase;
+
  public:
   enum {
     // core archive spaces
@@ -83,10 +86,17 @@ class MetaspaceShared : AllStatic {
     n_regions =  last_valid_region + 1 // total number of regions
   };
 
+  static bool is_in_parallel_phase() {
+    CDS_ONLY(return _is_in_parallel_phase);
+    NOT_CDS(return false);
+  }
+
   static void prepare_for_dumping() NOT_CDS_RETURN;
   static void preload_and_dump(TRAPS) NOT_CDS_RETURN;
   static int preload_classes(const char * class_list_path,
                              TRAPS) NOT_CDS_RETURN_(0);
+  static void preprocess_for_dumping_during_parallel_phase(
+                             Klass* k,Thread* THREAD) NOT_CDS_RETURN;
 
   static GrowableArray<Klass*>* collected_klasses();
 
@@ -191,5 +201,16 @@ class MetaspaceShared : AllStatic {
 
 private:
   static void read_extra_data(const char* filename, TRAPS) NOT_CDS_RETURN;
+
+  static void collect_archivable_classes() NOT_CDS_RETURN;
+
+  static bool try_link_and_set_error_state(
+      InstanceKlass* ik, TRAPS) NOT_CDS_RETURN;
+
+  static void rewrite_nofast_bytecodes_and_calculate_fingerprints(
+      InstanceKlass* ik) NOT_CDS_RETURN;
+
+  static void resolve_constants_and_update_constMethods(
+      Thread* THREAD) NOT_CDS_RETURN;
 };
 #endif // SHARE_VM_MEMORY_METASPACESHARED_HPP

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -1245,10 +1245,6 @@ public:
   u2 idnum_allocated_count() const      { return _idnum_allocated_count; }
 
 public:
-  void set_in_error_state() {
-    assert(DumpSharedSpaces, "only call this when dumping archive");
-    _init_state = initialization_error;
-  }
   bool check_sharing_error_state();
 
 private:
@@ -1279,6 +1275,7 @@ public:
 private:
   void fence_and_clear_init_lock();
 
+  void check_error_state                         (TRAPS);
   bool link_class_impl                           (bool throw_verifyerror, TRAPS);
   bool verify_code                               (bool throw_verifyerror, TRAPS);
   void initialize_impl                           (TRAPS);

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -599,6 +599,13 @@ JVM_ENTRY(jint, JVM_MoreStackWalk(JNIEnv *env, jobject stackStream, jlong mode, 
                                    start_index, frames_array_h, THREAD);
 JVM_END
 
+JVM_ENTRY(void, JVM_PreprocessClassAtDumpTime(JNIEnv *env, jclass k))
+  oop k_oop = JNIHandles::resolve(k);
+  assert(k_oop != NULL, "sanity");
+  Klass* k_k = java_lang_Class::as_Klass(k_oop);
+  MetaspaceShared::preprocess_for_dumping_during_parallel_phase(k_k, THREAD);
+JVM_END
+
 // java.lang.Object ///////////////////////////////////////////////
 
 

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3168,6 +3168,10 @@ jint Arguments::finalize_vm_init_args(bool patch_mod_javabase) {
 
 #if INCLUDE_CDS
   if (DumpSharedSpaces) {
+    if (ActiveProcessorCount > 0 && FLAG_IS_DEFAULT(DumpWithParallelism)) {
+      FLAG_SET_ERGO(int, DumpWithParallelism, ActiveProcessorCount);
+    }
+
     // Disable biased locking now as it interferes with the clean up of
     // the archived Klasses and Java string objects (at dump time only).
     UseBiasedLocking = false;

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2489,6 +2489,15 @@ define_pd_global(uint64_t,MaxRAM,                    1ULL*G);
           "Special mode: JVM reads a class list, loads classes, builds "    \
           "shared spaces, and dumps the shared spaces to a file to be "     \
           "used in future JVM runs")                                        \
+  /* Google: Perform parallel class loading, linking and other          */  \
+  /*         parallel-capable preprocessing operations in different     */  \
+  /*         Java threads to speed up CDS archive creation. The number  */  \
+  /*         of Java threads is determined by DumpWithParallelism       */  \
+  /*         value. If DumpWithParallelism is 1, all CDS archiving      */  \
+  /*         operations are done using one thread.                      */  \
+  product(int, DumpWithParallelism, 4,                                      \
+          "Load and pre-process classes in parallel during CDS dumping")    \
+          range(1, 128)                                                     \
                                                                             \
   product(bool, PrintSharedArchiveAndExit, false,                           \
           "Print shared archive file contents")                             \

--- a/src/java.base/share/classes/jdk/internal/vm/CDSParallelPreProcessor.java
+++ b/src/java.base/share/classes/jdk/internal/vm/CDSParallelPreProcessor.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2020 Google, Inc.  All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  This particular file is
+ * subject to the "Classpath" exception as provided in the LICENSE file
+ * that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.internal.vm;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Support loading and pre-processing classes in parallel at CDS dump time.
+ *
+ * CDS dumping involves a parallel phase and a non-parallel phase. The static
+ * CDSParallelPreProcessor.preLoadAndProcess() method is invoked by the VM to
+ * enter the parallel phase.
+ *
+ * During the parallel phase, the classlist is split into a number of sublists
+ * according to DumpWithParallelism value and processed parallelly in different
+ * tasks. Classes on the list are loaded but not explicitly initialized, and
+ * then pre-processed. Pre-processing classes during the parallel phase includes
+ * linking class, verifying class (when required), and rewriting bytecodes.
+ * After all parallel tasks complete, the control is transferred back to the VM,
+ * which then enters the non-parallel phase to further process the loaded data
+ * and create the archive file.
+ */
+public class CDSParallelPreProcessor {
+
+    // Total number of loaded classes.
+    private static AtomicInteger classCount = new AtomicInteger(0);
+
+    static void updateClassCount(int num) {
+        classCount.getAndAdd(num);
+    }
+
+    private static class SubListProcessor implements Runnable {
+        List<String> classList;
+        SubListProcessor(List<String> list) {
+            classList = list;
+        }
+
+        @Override
+        public void run() {
+            updateClassCount(processSubList(classList));
+        }
+    }
+
+    // Read the 'classListFile' and split the list into a number of sublists
+    // according to the value of 'parallelism' argument (determined by
+    // the VM DumpWithParallelism flag).
+    //
+    // The sublists are handled parallelly to load and pre-process classes.
+    // Wait for all worker threads to complete and collect the total number
+    // of loaded classes.
+    public static int preLoadAndProcess(String classListFile,
+                                        int parallelism) throws Throwable {
+        // Potentially this could be implemented using ExecutorService. However
+        // the thread management in ExecutorService is opaque to us. The
+        // pooled threads may not stop immediately when shutdown() or
+        // shutdownNow() is called and may be interrupted at a later point.
+        // To avoid any unwanted side-effects, which include concurrently
+        // loading any new classes due to executing Java code after this method
+        // is returned, an approach using direct thread management is chosen
+        // here.
+        List<List<String>> subLists = getSortedAndSplitClassList(
+                Files.readAllLines(Paths.get(classListFile)), parallelism);
+        Thread[] workers = new Thread[parallelism];
+        int num = 0;
+        for (List<String> list : subLists) {
+            workers[num] = new Thread(new SubListProcessor(list));
+            workers[num].start();
+            num++;
+        }
+        for (int i = 0; i < num; i++) {
+            workers[i].join();
+        }
+        return classCount.get();
+    }
+
+    /*
+     * Google: This method is a duplicate of FrameworkLoader.java.
+     */
+    static List<List<String>> getSortedAndSplitClassList(List<String> classesToLoad,
+                                                         int splitCount) {
+        Collections.sort(classesToLoad);
+
+        List<List<String>> returnList = new ArrayList<>(splitCount);
+        // The loop is index based so List.subList can be used easily.
+        int nextIndex = 0;
+        int remainingThreads = splitCount;
+        int totalClassCount = classesToLoad.size();
+        int remainingClasses = totalClassCount - nextIndex;
+        for (;
+            remainingClasses > 0 && remainingThreads > 0;
+            remainingClasses = totalClassCount - nextIndex) {
+          int sublistStartIndex = nextIndex;
+          int splitSize = (int) Math.max(1, remainingClasses / (double) remainingThreads);
+          nextIndex += splitSize;
+          // Find the index of the next non-inner class.
+          for (;
+              nextIndex < totalClassCount && classesToLoad.get(nextIndex).indexOf('$') != -1;
+              nextIndex++) {}
+          List<String> subList = classesToLoad.subList(sublistStartIndex, nextIndex);
+          returnList.add(subList);
+          remainingThreads--;
+        }
+        return returnList;
+    }
+
+    // The 'subList' is a segment of the original classlist that's produced by
+    // getSortedAndSplitClassList() method. Lines start with '#' are comments
+    // and are ignored. Lines start with '[' are treated as array and are not
+    // supported for classlist.
+    //
+    // For each class entry in the 'subList', load the class without
+    // initializing, and pre-process the loaded class. Pre-processing includes
+    // linking the class, verifying the the class if required and rewriting the
+    // bytecodes. It is not a fatal error if a class in the classlist cannot be
+    // found. A 'Preload Warning' is printed out in that case.
+    //
+    // The number of successfully loaded classes is tracked and returned.
+    static int processSubList(List<String> subList) {
+        int classNum = 0;
+        for (String name : subList) {
+            if (name.startsWith("#")) {
+                // Line starts with '#' is treated as comment and is ignored.
+            } else if (name.startsWith("[")) {
+                // Array is not support in classlist.
+                System.out.println("Preload Warning: Cannot find " + name);
+            } else {
+                String qualified_name = name.replace('/', '.');
+                Class<?> c = null;
+                try {
+                    // First try loading the requested class by calling the
+                    // system class loader's loadClass(). That handles all
+                    // following cases:
+                    //
+                    // - classes in the runtime modules image
+                    // - application classes with unnamed modules from -cp path
+                    // - application classes with named module from the module
+                    //   path
+                    // - unnamed module classes from -Xbootclasspath/a:
+                    c = ClassLoader.getSystemClassLoader().loadClass(qualified_name);
+                } catch (Throwable t) {
+                    // Ignore any exception
+                }
+
+                try {
+                    if (c == null) {
+                      // Additional classes with existing named modules defined
+                      // in the runtime modules image can be loaded from
+                      // -Xbootclasspath/a. That case is not handled by system
+                      // class loader's loadClass(). Call Class.forName() using
+                      // the null class loader explicitly to handle that.
+                      c = Class.forName(qualified_name, false, null);
+                    }
+                    preProcessClass(c);
+                    classNum ++;
+                } catch (ClassNotFoundException | NoClassDefFoundError ex) {
+                    System.out.println("Preload Warning: Cannot find " + name);
+                } catch (UnsupportedClassVersionError err) {
+                    // Error is already reported by the VM
+                }
+            }
+        }
+        return classNum;
+    }
+
+    private static native void preProcessClass(Class<?> c);
+}

--- a/src/java.base/share/native/libjava/CDSParallelPreProcessor.c
+++ b/src/java.base/share/native/libjava/CDSParallelPreProcessor.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Google, Inc.  All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  This particular file is
+ * subject to the "Classpath" exception as provided in the LICENSE file
+ * that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "jni.h"
+#include "jvm.h"
+
+#include "jdk_internal_vm_CDSParallelPreProcessor.h"
+
+JNIEXPORT void JNICALL
+Java_jdk_internal_vm_CDSParallelPreProcessor_preProcessClass(
+    JNIEnv *env, jclass cls, jclass k)
+{
+    return JVM_PreprocessClassAtDumpTime(env, k);
+}

--- a/test/hotspot/jtreg/runtime/SharedArchiveFile/DumpWithParallelism.java
+++ b/test/hotspot/jtreg/runtime/SharedArchiveFile/DumpWithParallelism.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2020, Google Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary Testing CDS dumping with DumpWithParallelism.
+ * @requires vm.cds
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run main DumpWithParallelism
+ */
+
+import jdk.test.lib.cds.CDSTestUtils;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class DumpWithParallelism {
+    public static void main(String[] args) throws Exception {
+        for (int i = 1; i <= 32; i *= 2) {
+            test(i);
+        }
+    }
+
+    static void test(int parallelism) throws Exception {
+        String jsa_name = "./DumpWithParallelism_" + parallelism + ".jsa";
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(true,
+                                "-XX:SharedArchiveFile=" + jsa_name,
+                                "-XX:DumpWithParallelism=" + parallelism,
+                                "-Xshare:dump");
+        OutputAnalyzer out = CDSTestUtils.executeAndLog(pb, "dump");
+        CDSTestUtils.checkDump(out);
+
+        pb = ProcessTools.createJavaProcessBuilder(true,
+                "-XX:SharedArchiveFile=" + jsa_name,
+                "-Xshare:on", "DumpWithParallelism$RuntimeTest");
+        CDSTestUtils.executeAndLog(pb, "exec").shouldHaveExitValue(0);;
+    }
+
+    static class RuntimeTest {
+        public static void main(String[] args) {
+            System.out.println("Runtime test");
+        }
+    }
+}

--- a/test/hotspot/jtreg/runtime/appcds/ProhibitedPackage.java
+++ b/test/hotspot/jtreg/runtime/appcds/ProhibitedPackage.java
@@ -54,7 +54,7 @@ public class ProhibitedPackage {
 
             // Make sure a class in a prohibited package for a custom loader
             // will be ignored during dumping.
-            TestCommon.dump(appJar,  classlist, "-Xlog:cds")
+            TestCommon.dump(appJar,  classlist, "-Xlog:cds", "-XX:DumpWithParallelism=1")
                 .shouldContain("Dumping")
                 .shouldContain("[cds] Prohibited package for non-bootstrap classes: java/lang/Prohibited.class")
                 .shouldHaveExitValue(0);

--- a/test/hotspot/jtreg/runtime/appcds/SameNameClasses.java
+++ b/test/hotspot/jtreg/runtime/appcds/SameNameClasses.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2020, Google Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @summary Test same named classes in both -cp and -Xbootclasspath/a. The
+ *          class in the -Xbootclasspath/a should be loaded.
+ * @requires vm.cds
+ * @library /test/lib ..
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run main SameNameClasses
+ */
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import jdk.test.lib.compiler.InMemoryJavaCompiler;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.util.JarUtils;
+
+public class SameNameClasses {
+    private final static String TEST_APP = "SameNameClassesTestApp";
+    private final static String TEST_CLASSES = System.getProperty("test.classes");
+    private final static String CP_DIR = TEST_CLASSES + "/CP/";
+    private final static Path CP_JAR_PATH = Paths.get(CP_DIR, "cp.jar");
+    private final static String BOOT_APPEND_DIR = TEST_CLASSES + "/boot_append/";
+    private final static Path BOOT_APPEND_JAR_PATH = Paths.get(CP_DIR, "boot_append.jar");
+
+    static String create_jar(String code, String dir, Path jar) throws Throwable {
+        String source = "public class " + TEST_APP + " { " +
+                        "    public static void main(String args[]) { " +
+                             code       +
+                        "    } "        +
+                        "}";
+        ClassFileInstaller.writeClassToDisk(
+            TEST_APP, InMemoryJavaCompiler.compile(TEST_APP, source), dir);
+
+        JarUtils.createJarFile(jar,
+                               Paths.get(dir),
+                               Paths.get(dir, TEST_APP + ".class"));
+        return jar.toString();
+    }
+
+    public static void main(String[] args) throws Throwable {
+        String cp_jar_path = create_jar(
+                   "System.out.println(\"From classpath!\");",
+                   CP_DIR, CP_JAR_PATH);
+        String boot_append_jar_path = create_jar(
+                   "System.out.println(\"From bootclasspath append!\");",
+                   BOOT_APPEND_DIR, BOOT_APPEND_JAR_PATH);
+
+        String[] appClasses = {TEST_APP};
+        OutputAnalyzer output = TestCommon.testDump(cp_jar_path, appClasses,
+                                     "-Xbootclasspath/a:" + boot_append_jar_path,
+                                     "-Xlog:class+load");
+        output.shouldMatch("SameNameClassesTestApp source: .*boot_append.jar");
+
+        TestCommon.run(
+            "-cp", cp_jar_path,
+            "-Xbootclasspath/a:" + boot_append_jar_path,
+            TEST_APP)
+                .assertNormalExit("From bootclasspath append");
+    }
+}

--- a/test/hotspot/jtreg/runtime/appcds/customLoader/ClassListFormatBase.java
+++ b/test/hotspot/jtreg/runtime/appcds/customLoader/ClassListFormatBase.java
@@ -41,7 +41,8 @@ public class ClassListFormatBase {
         System.out.println("------------------------------");
 
         try {
-            OutputAnalyzer output = TestCommon.dump(appJar, appClasses);
+            OutputAnalyzer output = TestCommon.dump(
+                appJar, appClasses, "-XX:DumpWithParallelism=1");
             output.shouldHaveExitValue(1);
             for (String s : expected_errors) {
                 output.shouldContain(s);
@@ -63,7 +64,8 @@ public class ClassListFormatBase {
         System.out.println("------------------------------");
 
         try {
-            OutputAnalyzer output = TestCommon.dump(appJar, appClasses);
+            OutputAnalyzer output = TestCommon.dump(
+                appJar, appClasses, "-XX:DumpWithParallelism=1");
             output.shouldHaveExitValue(0);
             output.shouldContain("Dumping");
             for (String s : expected_msgs) {

--- a/test/hotspot/jtreg/runtime/appcds/customLoader/HelloCustom.java
+++ b/test/hotspot/jtreg/runtime/appcds/customLoader/HelloCustom.java
@@ -60,6 +60,7 @@ public class HelloCustom {
         OutputAnalyzer output;
         TestCommon.testDump(appJar, classlist,
                             // command-line arguments ...
+                            "-XX:DumpWithParallelism=1",
                             use_whitebox_jar);
 
         output = TestCommon.exec(appJar,

--- a/test/hotspot/jtreg/runtime/appcds/customLoader/ParallelTestBase.java
+++ b/test/hotspot/jtreg/runtime/appcds/customLoader/ParallelTestBase.java
@@ -85,7 +85,8 @@ public class ParallelTestBase {
         }
 
         OutputAnalyzer output;
-        TestCommon.testDump(appJar, TestCommon.concat(app_list, cust_list));
+        TestCommon.testDump(appJar, TestCommon.concat(app_list, cust_list),
+                            "-XX:DumpWithParallelism=1");
 
         String loaderTypeArg = (loaderType == SINGLE_CUSTOM_LOADER) ? "SINGLE_CUSTOM_LOADER" : "MULTI_CUSTOM_LOADER";
         String modeArg = "FINGERPRINT_MODE";

--- a/test/hotspot/jtreg/runtime/appcds/customLoader/ProtectionDomain.java
+++ b/test/hotspot/jtreg/runtime/appcds/customLoader/ProtectionDomain.java
@@ -49,7 +49,7 @@ public class ProtectionDomain {
             "ProtDomainClassForArchive id: 3 super: 1 source: " + customJar
         };
 
-        TestCommon.testDump(appJar, classlist);
+        TestCommon.testDump(appJar, classlist, "-XX:DumpWithParallelism=1");
 
         // First class is loaded from CDS, second class is loaded from JAR
         TestCommon.checkExec(TestCommon.exec(appJar, "-verbose:class", "ProtDomain", customJar),

--- a/test/hotspot/jtreg/runtime/appcds/customLoader/SameNameInTwoLoadersTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/customLoader/SameNameInTwoLoadersTest.java
@@ -68,7 +68,7 @@ public class SameNameInTwoLoadersTest {
         String testClass, String testCaseId) throws Exception {
         classlist[0] = testClass;
 
-        TestCommon.testDump(appJar, classlist, useWbParam);
+        TestCommon.testDump(appJar, classlist, "-XX:DumpWithParallelism=1", useWbParam);
 
         OutputAnalyzer output = TestCommon.exec(appJar,
                                  // command-line arguments ...

--- a/test/hotspot/jtreg/runtime/appcds/customLoader/UnintendedLoadersTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/customLoader/UnintendedLoadersTest.java
@@ -60,7 +60,8 @@ public class UnintendedLoadersTest {
         OutputAnalyzer output;
         TestCommon.testDump(appJar, classlist,
                             // command-line arguments ...
-                            use_whitebox_jar);
+                            use_whitebox_jar,
+                            "-XX:DumpWithParallelism=1");
 
         output = TestCommon.exec(appJar,
                                  // command-line arguments ...

--- a/test/hotspot/jtreg/runtime/appcds/customLoader/UnloadUnregisteredLoaderTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/customLoader/UnloadUnregisteredLoaderTest.java
@@ -67,7 +67,8 @@ public class UnloadUnregisteredLoaderTest {
         OutputAnalyzer output;
         TestCommon.testDump(classpath, classlist,
                             // command-line arguments ...
-                            use_whitebox_jar);
+                            use_whitebox_jar,
+                            "-XX:DumpWithParallelism=1");
 
         output = TestCommon.exec(classpath,
                                  // command-line arguments ...

--- a/test/hotspot/jtreg/runtime/appcds/jvmti/transformRelatedClasses/TransformRelatedClassesAppCDS.java
+++ b/test/hotspot/jtreg/runtime/appcds/jvmti/transformRelatedClasses/TransformRelatedClassesAppCDS.java
@@ -180,7 +180,8 @@ public class TransformRelatedClassesAppCDS extends TransformRelatedClasses {
                                      String agentJar, String customJar)
         throws Exception {
 
-        OutputAnalyzer out = TestCommon.dump(appJar, classList);
+        OutputAnalyzer out = TestCommon.dump(appJar, classList,
+                                             "-XX:DumpWithParallelism=1");
         TestCommon.checkDump(out);
 
         String agentParam = "-javaagent:" + agentJar + "=" +


### PR DESCRIPTION
Optimizations for faster CDS creation:

- Separate the CDS archive creation into parallel phase and non-parallel phase. Introduce DumpWithParallelism VM flag to specify the number of Java threads for the parallel phase. If DumpWithParallelism is 1, all CDS archiving operations are done using one thread as before.

Parallel phase
==============
The static CDSParallelPreProcessor.preLoadAndProcess() method is the entry point of the parallel phase.

During the parallel phase, the classlist is split into a number of sublists based on the DumpWithParallelism value and processed parallely in different threads. Classes on the list are loaded but not explicitly initialized.  Loaded classes are linked and verified (when required).

CDSParallelPreProcessor.preLoadAndProcess() waits for all parallel tasks until they are completed, and transfers the control back to the VM, which then enters the non-parallel phase.

Non-parallel phase
==================
* Initialize classes with archived static fields.
* Iterate ClassLoaderDataGraph and link/verify any classes that are not linked. Verification may cause more classes being loaded.
* Collect archivable classes.
* Resolve constants.
* Rewrite nofast bytecode.
* Remove unsharable data.
* Copy class metadata.
* Copy Java heap objects.
* Write archive file.

- Move ClassLoaderDataGraph::loaded_classes_do(&collect_classes) (collects all archivable classes) to an earlier place, so resolve_class_constants() (resolves archivable constant pool references) can be called for archivable classes only to avoid wasted work for classes that are not included in the archive.

- Move resolve_class_constants() out of LinkSharedClassesClosure, and only call that for archivable classes in _global_klass_objects. The VM iterates all classes in ClassLoaderDataGraphs and calls linkedLinkSharedClassesClosure to link classes. Class verification during linking may load additional new classes, so multiple iterations of ClassLoaderDataGraphs are done until there is no more new class. resolve_class_constants() only needs to be done once.

- Combine the operations for resolving archivable constant pool references and nofast bytecode rewriting, and do both within a single _global_klass_objects iteration.

- Avoid unnecessary is_array_klass() check in collect_array_classes().

- Track the number of instance Klasses, object arrays and type arrays in CollectClassesClosure. Avoid an extra iteration of the _global_klass_objects to collect the stats.

- Change the initial _global_klass_objects (growable) size from 1,000 to 200,000 to avoid the overhead for growing the array.

This PR only includes linux-x86 16-bit Atomic::cmpxchg support. I have a separate patch for linux-aarch64 16-bit CAS operation and will contribute via a separate PR.

Author: Jiangli Zhou, Jeff Barcalow
Reviewed by: Man Cao, Martin Buchholz