### PR TITLE
Add UseHeapObjectArchiving option.

### DIFF
--- a/src/hotspot/share/memory/filemap.cpp
+++ b/src/hotspot/share/memory/filemap.cpp
@@ -985,8 +985,9 @@ MemRegion FileMapInfo::get_heap_regions_range_with_current_oop_encoding_mode() {
 // open archive objects.
 void FileMapInfo::map_heap_regions_impl() {
   if (!HeapShared::is_heap_object_archiving_allowed()) {
-    log_info(cds)("CDS heap data is being ignored. UseG1GC, "
-                  "UseCompressedOops and UseCompressedClassPointers are required.");
+    log_info(cds)("CDS heap data is being ignored. UseHeapObjectArchiving, "
+                  "UseG1GC, UseCompressedOops and UseCompressedClassPointers "
+                  "are required.");
     return;
   }
 

--- a/src/hotspot/share/memory/heapShared.cpp
+++ b/src/hotspot/share/memory/heapShared.cpp
@@ -184,10 +184,12 @@ void HeapShared::archive_java_heap_objects(GrowableArray<MemRegion> *closed,
   if (!is_heap_object_archiving_allowed()) {
     if (log_is_enabled(Info, cds)) {
       log_info(cds)(
-        "Archived java heap is not supported as UseG1GC, "
-        "UseCompressedOops and UseCompressedClassPointers are required."
-        "Current settings: UseG1GC=%s, UseCompressedOops=%s, UseCompressedClassPointers=%s.",
-        BOOL_TO_STR(UseG1GC), BOOL_TO_STR(UseCompressedOops),
+        "Archived java heap is not supported as UseHeapObjectArchiving, "
+        "UseG1GC, UseCompressedOops and UseCompressedClassPointers are "
+        "required. Current settings: UseHeapObjectArchiving=%s, UseG1GC=%s, "
+        "UseCompressedOops=%s, UseCompressedClassPointers=%s.",
+        BOOL_TO_STR(UseHeapObjectArchiving),BOOL_TO_STR(UseG1GC),
+        BOOL_TO_STR(UseCompressedOops),
         BOOL_TO_STR(UseCompressedClassPointers));
     }
     return;

--- a/src/hotspot/share/memory/heapShared.hpp
+++ b/src/hotspot/share/memory/heapShared.hpp
@@ -282,7 +282,7 @@ class HeapShared: AllStatic {
 
  public:
   static bool is_heap_object_archiving_allowed() {
-    CDS_JAVA_HEAP_ONLY(return (UseG1GC && UseCompressedOops && UseCompressedClassPointers);)
+    CDS_JAVA_HEAP_ONLY(return (UseHeapObjectArchiving && UseG1GC && UseCompressedOops && UseCompressedClassPointers);)
     NOT_CDS_JAVA_HEAP(return false;)
   }
 

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2498,6 +2498,12 @@ define_pd_global(uint64_t,MaxRAM,                    1ULL*G);
   product(int, DumpWithParallelism, 4,                                      \
           "Load and pre-process classes in parallel during CDS dumping")    \
           range(1, 128)                                                     \
+  /* Google: DisableHeapObjectArchiving is currently a Google JVM */        \
+  /*         internal option. It is planned to upstream this to OpenJDK. */ \
+  product(bool, UseHeapObjectArchiving, true,                               \
+          "Use heap object archiving. Note that heap archiving is only "    \
+          "available with G1 GC, so this flag will only have an effect if " \
+          "G1 GC is enabled.")                                              \
                                                                             \
   product(bool, PrintSharedArchiveAndExit, false,                           \
           "Print shared archive file contents")                             \

--- a/test/hotspot/jtreg/runtime/appcds/cacheObject/MirrorWithReferenceFieldsApp.java
+++ b/test/hotspot/jtreg/runtime/appcds/cacheObject/MirrorWithReferenceFieldsApp.java
@@ -75,7 +75,7 @@ public class MirrorWithReferenceFieldsApp {
             // Check fields
 
             if (wb.isShared(archived_field)) {
-                System.out.println("archived_field is archived as excepted");
+                System.out.println("archived_field is archived as expected");
             } else {
                 throw new RuntimeException(
                     "FAILED. archived_field is not archived.");

--- a/test/hotspot/jtreg/runtime/appcds/cacheObject/UseHeapObjectArchivingApp.java
+++ b/test/hotspot/jtreg/runtime/appcds/cacheObject/UseHeapObjectArchivingApp.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2020, Google Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import sun.hotspot.WhiteBox;
+
+// Test objects should be archived in heap when UseHeapObjectArchiving is True at both dump time
+// and runtime.
+public class UseHeapObjectArchivingApp {
+
+    // Static String field with initial value
+    static final String archived_field = "abc";
+
+    public UseHeapObjectArchivingApp() {}
+
+    public static void main(String args[]) throws Exception {
+        WhiteBox wb = WhiteBox.getWhiteBox();
+
+        new UseHeapObjectArchivingApp().test(wb);
+    }
+
+    public void test(WhiteBox wb) {
+        Class c = UseHeapObjectArchivingApp.class;
+        if (wb.isSharedClass(c)) {
+            boolean is_class_archived = wb.isShared(c);
+            boolean is_field_archived = wb.isShared(archived_field);
+
+            if (is_class_archived && is_field_archived) {
+              System.out.println(c + " class and its field are archived.");
+            } else if (!is_class_archived && !is_field_archived) {
+              System.out.println(c + " class and its field are not archived.");
+            } else {
+              throw new RuntimeException("ERROR: discrepancy between archival state of class " +
+                                         "object " + c + " and its field.");
+            }
+
+            // GC should not crash
+            System.gc();
+            System.gc();
+            System.gc();
+        }
+    }
+}

--- a/test/hotspot/jtreg/runtime/appcds/cacheObject/UseHeapObjectArchivingTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/cacheObject/UseHeapObjectArchivingTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2020, Google Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test UseHeapObjectArchiving flag.
+ * @requires vm.cds.archived.java.heap
+ * @library /test/lib /test/hotspot/jtreg/runtime/appcds
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ *          jdk.jartool/sun.tools.jar
+ * @build sun.hotspot.WhiteBox
+ * @compile UseHeapObjectArchivingApp.java
+ * @run driver ClassFileInstaller -jar app.jar UseHeapObjectArchivingApp
+ * @run driver ClassFileInstaller -jar WhiteBox.jar sun.hotspot.WhiteBox
+ * @run main UseHeapObjectArchivingTest
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+import sun.hotspot.WhiteBox;
+
+
+public class UseHeapObjectArchivingTest {
+    public static void main(String[] args) throws Exception {
+        String wbJar = ClassFileInstaller.getJarPath("WhiteBox.jar");
+        String use_whitebox_jar = "-Xbootclasspath/a:" + wbJar;
+        String appJar = ClassFileInstaller.getJarPath("app.jar");
+
+        String classlist[] = new String[] {
+            "UseHeapObjectArchivingApp",
+        };
+
+        // Disable heap object archiving at dump time, and generate a dump.
+        TestCommon.testDump(appJar, classlist, use_whitebox_jar, "-XX:-UseHeapObjectArchiving");
+
+        // Test case where we disable heap object archiving at dump time and runtime.
+        OutputAnalyzer output = TestCommon.exec(appJar, use_whitebox_jar,
+                                                "-XX:-UseHeapObjectArchiving",
+                                                "-XX:+WhiteBoxAPI",
+                                                "-XX:+VerifyAfterGC",
+                                                "UseHeapObjectArchivingApp");
+        TestCommon.checkExec(output,
+                             "class " + classlist[0] + " class and its field are not archived");
+
+        // Test case where we disable heap object archiving at dump time but enable at runtime.
+        output = TestCommon.exec(appJar, use_whitebox_jar,
+                                 "-XX:+UseHeapObjectArchiving",
+                                 "-XX:+WhiteBoxAPI",
+                                 "-XX:+VerifyAfterGC",
+                                 "UseHeapObjectArchivingApp");
+        TestCommon.checkExec(output,
+                             "class " + classlist[0] + " class and its field are not archived");
+
+        // Enable heap object archiving at dump time, and generate a dump.
+        TestCommon.testDump(appJar, classlist, use_whitebox_jar, "-XX:+UseHeapObjectArchiving");
+
+        // Test case where we enable heap object archiving at dump time and runtime.
+        output = TestCommon.exec(appJar, use_whitebox_jar,
+                                 "-XX:+UseHeapObjectArchiving",
+                                 "-XX:+WhiteBoxAPI",
+                                 "-XX:+VerifyAfterGC",
+                                 "UseHeapObjectArchivingApp");
+        TestCommon.checkExec(output,
+                             "class " + classlist[0] + " class and its field are archived");
+
+        // Test case where we enable heap object archiving at dump time but disable at runtime.
+        output = TestCommon.exec(appJar, use_whitebox_jar,
+                                 "-XX:-UseHeapObjectArchiving",
+                                 "-XX:+WhiteBoxAPI",
+                                 "-XX:+VerifyAfterGC",
+                                 "UseHeapObjectArchivingApp");
+        TestCommon.checkExec(output,
+                             "class " + classlist[0] + " class and its field are not archived");
+    }
+}


### PR DESCRIPTION
Currently the Java heap object archiving is enabled by default. It may be desirable to make the support configurable. That's helpful for performance comparisons, and in some use cases users might want to disable heap archiving due to specific requirements. As heap archiving is only supported for G1 currently, using other GC algorithms at archiving creation time could be employed as a workaround for disabling the support. Adding the specific command line option(s) for that would provide better developer experiences. 

This PR adds a flag that can be passed in at dump time or runtime to prevent objects from being archived in the heap.

Author: jonathanjoo@google.com
Reviewed: jianglizhou@google.com