### PR TITLE
Core algorithms and mechanism for general Java class pre-initialize support for JDK classes.

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.hpp
+++ b/src/hotspot/share/classfile/classFileParser.hpp
@@ -161,6 +161,8 @@ class ClassFileParser {
   bool _declares_nonstatic_concrete_methods;
   bool _has_final_method;
 
+  bool _has_clinit_or_static_field;
+
   // precomputed flags
   bool _has_finalizer;
   bool _has_empty_finalizer;

--- a/src/hotspot/share/classfile/classLoader.cpp
+++ b/src/hotspot/share/classfile/classLoader.cpp
@@ -1617,11 +1617,18 @@ void ClassLoader::record_result(InstanceKlass* ik, const ClassFileStream* stream
       }
     }
 
-    // No path entry found for this class. Must be a shared class loaded by the
-    // user defined classloader.
+    // No path entry found for this class. It could be a shared class loaded by
+    // the user defined classloader. Or it could be a klass with no file-backed
+    // ClassFileStream source (VM defined classes), in which case the
+    // shared_classpath_index is -1.
     if (classpath_index < 0) {
       assert(ik->shared_classpath_index() < 0, "Sanity");
-      return;
+      if (ik->shared_classpath_index() == -1) {
+        // This is a class with no file-backed ClassFileStream source.
+        classpath_index = 0;
+      } else {
+        return;
+      }
     }
   } else {
     // The shared path table is set up after module system initialization.

--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -269,6 +269,8 @@ class java_lang_Class : AllStatic {
   static void serialize_offsets(SerializeClosure* f) NOT_CDS_RETURN;
   static void archive_basic_type_mirrors(TRAPS) NOT_CDS_JAVA_HEAP_RETURN;
   static oop  archive_mirror(Klass* k, TRAPS) NOT_CDS_JAVA_HEAP_RETURN_(NULL);
+  static void reset_mirror_static_fields(Klass *k, oop mirror, Thread *THREAD)
+                                         NOT_CDS_JAVA_HEAP_RETURN;
   static oop  process_archived_mirror(Klass* k, oop mirror, oop archived_mirror, Thread *THREAD)
                                       NOT_CDS_JAVA_HEAP_RETURN_(NULL);
   static bool restore_archived_mirror(Klass *k, Handle class_loader, Handle module,

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -1026,7 +1026,7 @@ InstanceKlass* SystemDictionary::parse_stream(Symbol* class_name,
     }
 
     // If it's anonymous, initialize it now, since nobody else will.
-    k->eager_initialize(CHECK_NULL);
+    k->eager_initialize(loader_data, CHECK_NULL);
 
     // notify jvmti
     if (JvmtiExport::should_post_class_load()) {
@@ -1624,7 +1624,7 @@ void SystemDictionary::define_instance_class(InstanceKlass* k, TRAPS) {
     update_dictionary(d_hash, p_index, p_hash,
                       k, class_loader_h, THREAD);
   }
-  k->eager_initialize(THREAD);
+  k->eager_initialize(loader_data, THREAD);
 
   // notify jvmti
   if (JvmtiExport::should_post_class_load()) {
@@ -1916,7 +1916,8 @@ void SystemDictionary::methods_do(void f(Method*)) {
 class RemoveClassesClosure : public CLDClosure {
   public:
     void do_cld(ClassLoaderData* cld) {
-      if (cld->is_system_class_loader_data() || cld->is_platform_class_loader_data()) {
+      if (cld->dictionary() != NULL &&
+          cld->is_system_class_loader_data() || cld->is_platform_class_loader_data()) {
         cld->dictionary()->remove_classes_in_error_state();
       }
     }

--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -139,6 +139,7 @@ class OopStorage;
   do_klass(PhantomReference_klass,                      java_lang_ref_PhantomReference,            Pre                 ) \
   do_klass(Finalizer_klass,                             java_lang_ref_Finalizer,                   Pre                 ) \
                                                                                                                          \
+  do_klass(Runnable_klass,                              java_lang_Runnable,                        Opt                 ) \
   do_klass(Thread_klass,                                java_lang_Thread,                          Pre                 ) \
   do_klass(ThreadGroup_klass,                           java_lang_ThreadGroup,                     Pre                 ) \
   do_klass(Properties_klass,                            java_util_Properties,                      Pre                 ) \

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -61,6 +61,7 @@
   template(java_lang_String,                          "java/lang/String")                         \
   template(java_lang_StringLatin1,                    "java/lang/StringLatin1")                   \
   template(java_lang_StringUTF16,                     "java/lang/StringUTF16")                    \
+  template(java_lang_Runnable,                        "java/lang/Runnable")                       \
   template(java_lang_Thread,                          "java/lang/Thread")                         \
   template(java_lang_ThreadGroup,                     "java/lang/ThreadGroup")                    \
   template(java_lang_Cloneable,                       "java/lang/Cloneable")                      \
@@ -662,6 +663,10 @@
   template(toFileURL_name,                         "toFileURL")                                                   \
   template(toFileURL_signature,                    "(Ljava/lang/String;)Ljava/net/URL;")                          \
   template(url_void_signature,                     "(Ljava/net/URL;)V")                                           \
+                                                                                                                  \
+  /* pre-initialization */                                                                                        \
+  template(com_google_common_annotations_Preserve_signature,  "Lcom/google/common/annotations/Preserve;")  \
+  template(jdk_internal_vm_annotation_Preserve_signature,     "Ljdk/internal/vm/annotation/Preserve;")            \
                                                                                                                   \
   /*end*/
 

--- a/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapVerifier.cpp
@@ -248,6 +248,14 @@ public:
     oop obj = RawAccess<>::oop_load(p);
 
     if (_hr->is_open_archive()) {
+      if (log_is_enabled(Debug, cds, heap)) {
+        ResourceMark rm;
+        log_debug(cds, heap)("Verifying " PTR_FORMAT " -> " PTR_FORMAT,
+                             p2i(p), p2i(obj));
+        LogTarget(Debug, cds, heap) log;
+        LogStream out(log);
+        obj->print_on(&out);
+      }
       guarantee(obj == NULL || G1ArchiveAllocator::is_archived_object(obj),
                 "Archive object at " PTR_FORMAT " references a non-archive object at " PTR_FORMAT,
                 p2i(p), p2i(obj));

--- a/src/hotspot/share/logging/logTag.hpp
+++ b/src/hotspot/share/logging/logTag.hpp
@@ -123,6 +123,7 @@
   LOG_TAG(plab) \
   LOG_TAG(preview)   /* Trace loading of preview feature types */ \
   LOG_TAG(promotion) \
+  LOG_TAG(preinit) \
   LOG_TAG(preorder) /* Trace all classes loaded in order referenced (not loaded) */ \
   LOG_TAG(protectiondomain) /* "Trace protection domain verification" */ \
   LOG_TAG(ref) \
@@ -149,6 +150,7 @@
   LOG_TAG(stringtable) \
   LOG_TAG(stackmap) \
   LOG_TAG(subclass) \
+  LOG_TAG(subgraphinfo) /* Trace heap archiving subgraph info records */ \
   LOG_TAG(survivor) \
   LOG_TAG(sweep) \
   LOG_TAG(system) \

--- a/src/hotspot/share/memory/heapShared.cpp
+++ b/src/hotspot/share/memory/heapShared.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "precompiled.hpp"
+#include "classfile/classLoaderData.inline.hpp"
 #include "classfile/javaClasses.inline.hpp"
 #include "classfile/stringTable.hpp"
 #include "classfile/symbolTable.hpp"
@@ -39,6 +40,7 @@
 #include "oops/compressedOops.inline.hpp"
 #include "oops/fieldStreams.hpp"
 #include "oops/oop.inline.hpp"
+#include "oops/markOop.hpp"
 #include "runtime/fieldDescriptor.inline.hpp"
 #include "runtime/safepointVerifiers.hpp"
 #include "utilities/bitMap.inline.hpp"
@@ -55,6 +57,9 @@ bool HeapShared::_archive_heap_region_fixed = false;
 address   HeapShared::_narrow_oop_base;
 int       HeapShared::_narrow_oop_shift;
 
+/*
+   Google: No longer needed with the new general class pre-initialization
+           support, which is more developer friendly and easier to use.
 //
 // If you add new entries to the following tables, you should know what you're doing!
 //
@@ -85,6 +90,7 @@ const static int num_closed_archive_subgraph_entry_fields =
   sizeof(closed_archive_subgraph_entry_fields) / sizeof(ArchivableStaticFieldInfo);
 const static int num_open_archive_subgraph_entry_fields =
   sizeof(open_archive_subgraph_entry_fields) / sizeof(ArchivableStaticFieldInfo);
+*/
 
 ////////////////////////////////////////////////////////////////
 //
@@ -139,10 +145,20 @@ oop HeapShared::archive_heap_object(oop obj, Thread* THREAD) {
   if (archived_oop != NULL) {
     Copy::aligned_disjoint_words((HeapWord*)obj, (HeapWord*)archived_oop, len);
     MetaspaceShared::relocate_klass_ptr(archived_oop);
+
+    // Reset markOop and retain the pre-computed identity hash.
+    archived_oop->set_mark_raw(
+      markOopDesc::prototype()->copy_set_hash(obj->identity_hash()));
+
     ArchivedObjectCache* cache = archived_object_cache();
     cache->put(obj, archived_oop);
     log_debug(cds, heap)("Archived heap object " PTR_FORMAT " ==> " PTR_FORMAT,
                          p2i(obj), p2i(archived_oop));
+    if (log_is_enabled(Trace, cds, heap)) {
+      LogTarget(Trace, cds, heap) log;
+      LogStream out(log);
+      obj->print_on(&out);
+    }
   } else {
     log_error(cds, heap)(
       "Cannot allocate space for object " PTR_FORMAT " in archived heap region",
@@ -195,7 +211,18 @@ void HeapShared::archive_java_heap_objects(GrowableArray<MemRegion> *closed,
     return;
   }
 
-  G1HeapVerifier::verify_ready_for_archiving();
+  // GOOGLE: G1HeapVerifier::verify_ready_for_archiving is not useful as it
+  //         starts from the lowest region and iterates upward to check if
+  //         there are allocated regions among the free regions.
+  //         VerifyReadyForArchivingRegionClosure::do_heap_region reports
+  //         'unexpected hole' if any non-humongous region is found after any
+  //         free regions. The G1ArchiveAllocator::alloc_new_region allocates
+  //         regions starting from the highest free region. The lower region
+  //         status does not affect archive regions allocation at all.
+  //         HeapShared::archive_heap_object ensures the consecutive archive
+  //         heap regions must be able to accommodate all archived heap objects.
+  //         Otherwise, it reports error and aborts the JVM.
+  //G1HeapVerifier::verify_ready_for_archiving();
 
   {
     NoSafepointVerifier nsv;
@@ -226,9 +253,16 @@ void HeapShared::copy_closed_archive_heap_objects(
   // Archive interned string objects
   StringTable::write_to_archive();
 
-  archive_object_subgraphs(closed_archive_subgraph_entry_fields,
-                           num_closed_archive_subgraph_entry_fields,
-                           true /* is_closed_archive */, THREAD);
+  // GOOGLE: All subgraph archiving are done in the open archive heap region
+  //         currently with the general class pre-initialization support.
+  //         For upstream, supporting archiving 'immutable' subgraphs in closed
+  //         archive heap region for memory sharing is desirable. Internally,
+  //         we also want to understand and evaluate the benefit of memory
+  //         sharing on Borg enviornment.
+  //
+  //archive_object_subgraphs(closed_archive_subgraph_entry_fields,
+  //                         num_closed_archive_subgraph_entry_fields,
+  //                         true /* is_closed_archive */, THREAD);
 
   G1CollectedHeap::heap()->end_archive_alloc_range(closed_archive,
                                                    os::vm_allocation_granularity());
@@ -241,14 +275,28 @@ void HeapShared::copy_open_archive_heap_objects(
   Thread* THREAD = Thread::current();
   G1CollectedHeap::heap()->begin_archive_alloc_range(true /* open */);
 
+  // Archive primitive type mirrors.
   java_lang_Class::archive_basic_type_mirrors(THREAD);
 
+  // Archive mirrors, constant pool resolved_references arrays, etc.
   archive_klass_objects(THREAD);
 
-  archive_object_subgraphs(open_archive_subgraph_entry_fields,
-                           num_open_archive_subgraph_entry_fields,
-                           false /* is_closed_archive */,
-                           THREAD);
+  if (PreInitializeArchivedClass) {
+    // Check object subgraphs referenced from the static fields.
+    check_preservable_klasses_and_fields(THREAD);
+
+    // TODO(b/168841205): All preservable static fields' object subgraphs are
+    // copied to the open archive heap regions currently. It probably worth
+    // supporting archiving using the closed archive heap regions for memory
+    // sharing. That would be desirable for upstream.
+
+    // Archive all individual static fields that are annotated with
+    // @Preserve.
+    archive_preservable_static_field_subgraphs(THREAD);
+
+    // Archive all static fields for classes with @Preserve.
+    archive_preservable_klass_static_fields_subgraphs(THREAD);
+  }
 
   G1CollectedHeap::heap()->end_archive_alloc_range(open_archive,
                                                    os::vm_allocation_granularity());
@@ -268,15 +316,26 @@ HeapShared::RunTimeKlassSubGraphInfoTable   HeapShared::_run_time_subgraph_info_
 // Get the subgraph_info for Klass k. A new subgraph_info is created if
 // there is no existing one for k. The subgraph_info records the relocated
 // Klass* of the original k.
-KlassSubGraphInfo* HeapShared::get_subgraph_info(Klass* k) {
-  assert(DumpSharedSpaces, "dump time only");
+KlassSubGraphInfo* HeapShared::get_subgraph_info(Klass* k,
+                                                 bool is_partial_pre_init) {
   Klass* relocated_k = MetaspaceShared::get_relocated_klass(k);
-  KlassSubGraphInfo* info = _dump_time_subgraph_info_table->get(relocated_k);
+  KlassSubGraphInfo* info = find_subgraph_info(relocated_k);
   if (info == NULL) {
-    _dump_time_subgraph_info_table->put(relocated_k, KlassSubGraphInfo(relocated_k));
+    _dump_time_subgraph_info_table->put(
+      relocated_k, KlassSubGraphInfo(relocated_k, is_partial_pre_init));
     info = _dump_time_subgraph_info_table->get(relocated_k);
     ++ _dump_time_subgraph_info_table->_count;
   }
+  return info;
+}
+
+// Find an existing KlassSubGraphInfo record for a relocated Klass.
+KlassSubGraphInfo* HeapShared::find_subgraph_info(Klass* relocated_k) {
+  assert(DumpSharedSpaces, "dump time only");
+  if (relocated_k == NULL) {
+    return NULL;
+  }
+  KlassSubGraphInfo* info = _dump_time_subgraph_info_table->get(relocated_k);
   return info;
 }
 
@@ -294,7 +353,8 @@ void KlassSubGraphInfo::add_subgraph_entry_field(
 }
 
 // Add the Klass* for an object in the current KlassSubGraphInfo's subgraphs.
-// Only objects of boot classes can be included in sub-graph.
+// Only objects of classes loaded by BUILTIN class loaders can be included in
+// sub-graph.
 void KlassSubGraphInfo::add_subgraph_object_klass(Klass* orig_k, Klass *relocated_k) {
   assert(DumpSharedSpaces, "dump time only");
   assert(relocated_k == MetaspaceShared::get_relocated_klass(orig_k),
@@ -314,21 +374,26 @@ void KlassSubGraphInfo::add_subgraph_object_klass(Klass* orig_k, Klass *relocate
   }
 
   if (relocated_k->is_instance_klass()) {
-    assert(InstanceKlass::cast(relocated_k)->is_shared_boot_class(),
-          "must be boot class");
+    // Only support shared classes with builtin class loaders and the
+    // shared_classpath_index must be >=0. See comments for BUILTIN type
+    // in systemDictionaryShared.hpp.
+    assert(relocated_k->shared_classpath_index() >= 0,
+          "must be BUILTIN type");
     // SystemDictionary::xxx_klass() are not updated, need to check
     // the original Klass*
     if (orig_k == SystemDictionary::String_klass() ||
-        orig_k == SystemDictionary::Object_klass()) {
+        orig_k == SystemDictionary::Object_klass() ||
+        orig_k == SystemDictionary::Class_klass()  ||
+        orig_k == SystemDictionary::Integer_klass()) {
       // Initialized early during VM initialization. No need to be added
-      // to the sub-graph object class list.
+      // to the sub-graph object dependency class list.
       return;
     }
   } else if (relocated_k->is_objArray_klass()) {
     Klass* abk = ObjArrayKlass::cast(relocated_k)->bottom_klass();
     if (abk->is_instance_klass()) {
-      assert(InstanceKlass::cast(abk)->is_shared_boot_class(),
-            "must be boot class");
+      guarantee(abk->shared_classpath_index() >= 0,
+                "must be BUILTIN type");
     }
     if (relocated_k == Universe::objectArrayKlassObj()) {
       // Initialized early during Universe::genesis. No need to be added
@@ -354,6 +419,7 @@ void KlassSubGraphInfo::add_subgraph_object_klass(Klass* orig_k, Klass *relocate
 // Initialize an archived subgraph_info_record from the given KlassSubGraphInfo.
 void ArchivedKlassSubGraphInfoRecord::init(KlassSubGraphInfo* info) {
   _k = info->klass();
+  _is_partial_pre_init = info->is_partial_pre_init();
   _entry_field_records = NULL;
   _subgraph_object_klasses = NULL;
 
@@ -369,7 +435,9 @@ void ArchivedKlassSubGraphInfoRecord::init(KlassSubGraphInfo* info) {
     }
   }
 
-  // the Klasses of the objects in the sub-graphs
+  // Add the Klasses of the objects in the sub-graphs to the dependency list.
+  // TODO(b/165809160): The list can be further optimized by removing any
+  // klasses that are already included in the current Klass's dependency list.
   GrowableArray<Klass*>* subgraph_object_klasses = info->subgraph_object_klasses();
   if (subgraph_object_klasses != NULL) {
     int num_subgraphs_klasses = subgraph_object_klasses->length();
@@ -434,109 +502,153 @@ void HeapShared::serialize_subgraph_info_table_header(SerializeClosure* soc) {
   _run_time_subgraph_info_table.serialize_header(soc);
 }
 
-void HeapShared::initialize_from_archived_subgraph(Klass* k) {
+bool HeapShared::initialize_from_archived_subgraph(Klass* k) {
   if (!open_archive_heap_region_mapped()) {
-    return; // nothing to do
+    return false; // nothing to do
   }
   assert(!DumpSharedSpaces, "Should not be called with DumpSharedSpaces");
 
+  Thread* THREAD = Thread::current();
+  ResourceMark rm(THREAD);
+  InstanceKlass* ik = InstanceKlass::cast(k);
+  if (ik->is_pre_initialized_without_dependency_class()) {
+    // Only has primitive type statics. Fully pre-initialized.
+    log_info(preinit)("%s static initializer has no dependency class, "
+                      "is fully pre-initialized", k->external_name());
+    return true;
+  }
+
   unsigned int hash = primitive_hash<Klass*>(k);
   ArchivedKlassSubGraphInfoRecord* record = _run_time_subgraph_info_table.lookup(k, hash, 0);
-
-  // Initialize from archived data. Currently this is done only
-  // during VM initialization time. No lock is needed.
-  if (record != NULL) {
-    Thread* THREAD = Thread::current();
-    if (log_is_enabled(Info, cds, heap)) {
-      ResourceMark rm;
-      log_info(cds, heap)("initialize_from_archived_subgraph " PTR_FORMAT " %s", p2i(k),
-                          k->external_name());
+  if (record == NULL) {
+    if (k->is_pre_initialized_with_dependency_class()) {
+      log_info(preinit)("%s is pre-initialized, dependencies are super types",
+                        k->external_name());
+      return true;
+    } else {
+      log_info(preinit)("%s is not pre-initialized", k->external_name());
+      return false;
     }
+  }
 
-    int i;
-    // Load/link/initialize the klasses of the objects in the subgraph.
-    // NULL class loader is used.
-    Array<Klass*>* klasses = record->subgraph_object_klasses();
-    if (klasses != NULL) {
-      for (i = 0; i < klasses->length(); i++) {
-        Klass* obj_k = klasses->at(i);
-        Klass* resolved_k = SystemDictionary::resolve_or_null(
-                                              (obj_k)->name(), THREAD);
-        if (resolved_k != obj_k) {
-          return;
-        }
-        if ((obj_k)->is_instance_klass()) {
-          InstanceKlass* ik = InstanceKlass::cast(obj_k);
-          ik->initialize(THREAD);
-        } else if ((obj_k)->is_objArray_klass()) {
-          ObjArrayKlass* oak = ObjArrayKlass::cast(obj_k);
-          oak->initialize(THREAD);
-        }
+  log_info(preinit)("initializing %s from archived subgraph",
+                    k->external_name());
+
+  // Initialize from archived data.
+  Handle loader (THREAD, k->class_loader());
+  Handle protection_domain (THREAD, k->protection_domain());
+
+  int i;
+  // Load/link/initialize the klasses of the objects in the subgraph.
+  // The current klass k's loader is used.
+  Array<Klass*>* klasses = record->subgraph_object_klasses();
+  if (klasses != NULL) {
+    for (i = 0; i < klasses->length(); i++) {
+      Klass* obj_k = klasses->at(i);
+      Klass* resolved_k = SystemDictionary::resolve_or_null(
+                   (obj_k)->name(), loader, protection_domain, THREAD);
+      if (resolved_k != obj_k) {
+        log_info(cds, heap)("Failed to load subgraph because %s was not "
+                            "loaded from archive", resolved_k->external_name());
+        return false;
+      }
+      if ((obj_k)->is_instance_klass()) {
+        InstanceKlass* ik = InstanceKlass::cast(obj_k);
+        ik->initialize(THREAD);
+      } else if ((obj_k)->is_objArray_klass()) {
+        ObjArrayKlass* oak = ObjArrayKlass::cast(obj_k);
+        oak->initialize(THREAD);
       }
     }
+  }
 
-    if (HAS_PENDING_EXCEPTION) {
-      CLEAR_PENDING_EXCEPTION;
-      // None of the field value will be set if there was an exception.
-      // The java code will not see any of the archived objects in the
-      // subgraphs referenced from k in this case.
-      return;
-    }
+  if (HAS_PENDING_EXCEPTION) {
+    CLEAR_PENDING_EXCEPTION;
+    // None of the field value(s) will be set if there was an exception.
+    // The java code will not see any of the archived objects in the
+    // subgraphs referenced from k in this case.
+    log_info(preinit)(
+      "Exception happened during initializing %s dependency classes",
+      k->external_name());
+    return false;
+  }
 
-    // Load the subgraph entry fields from the record and store them back to
-    // the corresponding fields within the mirror.
-    oop m = k->java_mirror();
-    Array<juint>* entry_field_records = record->entry_field_records();
-    if (entry_field_records != NULL) {
-      int efr_len = entry_field_records->length();
-      assert(efr_len % 3 == 0, "sanity");
-      for (i = 0; i < efr_len;) {
-        int field_offset = entry_field_records->at(i);
-        narrowOop nv = entry_field_records->at(i+1);
-        int is_closed_archive = entry_field_records->at(i+2);
-        oop v;
-        if (is_closed_archive == 0) {
-          // It's an archived object in the open archive heap regions, not shared.
-          // The object refereced by the field becomes 'known' by GC from this
-          // point. All objects in the subgraph reachable from the object are
-          // also 'known' by GC.
-          v = materialize_archived_object(nv);
-        } else {
-          // Shared object in the closed archive heap regions. Decode directly.
-          assert(!CompressedOops::is_null(nv), "shared object is null");
-          v = HeapShared::decode_from_archive(nv);
-        }
-        m->obj_field_put(field_offset, v);
-        i += 3;
+  if (!record->is_partial_pre_init()) {
+    // Fully pre-initialized.
+    assert(k->is_pre_initialized_with_dependency_class(), "sanity");
+    log_info(preinit)("%s is fully pre-initialized", k->external_name());
+    return true;
+  }
 
-        log_debug(cds, heap)("  " PTR_FORMAT " init field @ %2d = " PTR_FORMAT, p2i(k), field_offset, p2i(v));
+  // Load the subgraph entry fields from the record and store them back to
+  // the corresponding fields within the mirror. Protected by the current
+  // klass' init_lock.
+  // No need to materialize the objects and write back to the fields
+  oop m = k->java_mirror();
+  Array<juint>* entry_field_records = record->entry_field_records();
+  if (entry_field_records != NULL) {
+    HandleMark hm(THREAD);
+    Handle h_init_lock(THREAD, ik->init_lock());
+    ObjectLocker ol(h_init_lock, THREAD, h_init_lock() != NULL);
+
+    int efr_len = entry_field_records->length();
+    assert(efr_len % 3 == 0, "sanity");
+    for (i = 0; i < efr_len;) {
+      int field_offset = entry_field_records->at(i);
+      narrowOop nv = entry_field_records->at(i+1);
+      int is_closed_archive = entry_field_records->at(i+2);
+      oop v;
+      if (is_closed_archive == 0) {
+        // It's an archived object in the open archive heap regions, not shared.
+        // The object refereced by the field becomes 'known' by GC from this
+        // point. All objects in the subgraph reachable from the object are
+        // also 'known' by GC.
+        v = materialize_archived_object(nv);
+      } else {
+        // Shared object in the closed archive heap regions. Decode directly.
+        assert(!CompressedOops::is_null(nv), "shared object is null");
+        v = HeapShared::decode_from_archive(nv);
       }
+      m->obj_field_put(field_offset, v);
+      i += 3;
+
+      log_debug(cds, heap)("  " PTR_FORMAT " init field @ %2d = " PTR_FORMAT,
+                           p2i(k), field_offset, p2i(v));
+    }
 
     // Done. Java code can see the archived sub-graphs referenced from k's
     // mirror after this point.
-    }
+    log_info(preinit)("%s " PTR_FORMAT " is partially pre-initialized",
+                        k->external_name(), p2i(k));
   }
+  return false;
 }
 
 class WalkOopAndArchiveClosure: public BasicOopIterateClosure {
   int _level;
   bool _is_closed_archive;
   bool _record_klasses_only;
+  // If _check_preservable_only is true, the current walk only checks subgraphs
+  // without archiving.
+  bool _check_preservable_only;
   KlassSubGraphInfo* _subgraph_info;
   oop _orig_referencing_obj;
   oop _archived_referencing_obj;
+  bool _is_preservable;
   Thread* _thread;
  public:
   WalkOopAndArchiveClosure(int level,
                            bool is_closed_archive,
                            bool record_klasses_only,
+                           bool check_preservable_only,
                            KlassSubGraphInfo* subgraph_info,
                            oop orig, oop archived, TRAPS) :
     _level(level), _is_closed_archive(is_closed_archive),
     _record_klasses_only(record_klasses_only),
+    _check_preservable_only(check_preservable_only),
     _subgraph_info(subgraph_info),
     _orig_referencing_obj(orig), _archived_referencing_obj(archived),
-    _thread(THREAD) {}
+    _is_preservable(true), _thread(THREAD) {}
   void do_oop(narrowOop *p) { WalkOopAndArchiveClosure::do_oop_work(p); }
   void do_oop(      oop *p) { WalkOopAndArchiveClosure::do_oop_work(p); }
 
@@ -561,18 +673,35 @@ class WalkOopAndArchiveClosure: public BasicOopIterateClosure {
         obj->print_on(&out);
       }
 
-      oop archived = HeapShared::archive_reachable_objects_from(
-          _level + 1, _subgraph_info, obj, _is_closed_archive, THREAD);
-      assert(archived != NULL, "VM should have exited with unarchivable objects for _level > 1");
-      assert(HeapShared::is_archived_object(archived), "must be");
+      if (_check_preservable_only) {
+        // Only walk the rest of the subgraph if we haven't encountered any
+        // non-preservable objects.
+        if (_is_preservable) {
+          _is_preservable = HeapShared::check_reachable_objects_from(
+                              _level + 1, obj, THREAD);
+        }
+      } else {
+        // Recursively walk and archive all reachable objects from the
+        // current one.
+        oop archived = HeapShared::archive_reachable_objects_from(
+            _level + 1, _subgraph_info, obj, _is_closed_archive, THREAD);
+        assert(archived != NULL,
+               "VM should have exited with unarchivable objects for _level > 1");
+        assert(HeapShared::is_archived_object(archived), "must be");
 
-      if (!_record_klasses_only) {
-        // Update the reference in the archived copy of the referencing object.
-        log_debug(cds, heap)("(%d) updating oop @[" PTR_FORMAT "] " PTR_FORMAT " ==> " PTR_FORMAT,
-                             _level, p2i(new_p), p2i(obj), p2i(archived));
-        RawAccess<IS_NOT_NULL>::oop_store(new_p, archived);
+        if (!_record_klasses_only) {
+          // Update the reference in the archived copy of the referencing object.
+          log_debug(cds, heap)("(%d) updating oop @[" PTR_FORMAT "] " PTR_FORMAT " ==> " PTR_FORMAT,
+                               _level, p2i(new_p), p2i(obj), p2i(archived));
+          RawAccess<IS_NOT_NULL>::oop_store(new_p, archived);
+        }
       }
     }
+  }
+
+ public:
+  bool is_preservable() {
+    return _is_preservable;
   }
 };
 
@@ -605,11 +734,21 @@ oop HeapShared::archive_reachable_objects_from(int level,
   assert(orig_obj != NULL, "must be");
   assert(!is_archived_object(orig_obj), "sanity");
 
-  // java.lang.Class instances cannot be included in an archived
-  // object sub-graph.
+  bool is_mirror = false;
+
+  // A java.lang.Class instance can be included in an archived object
+  // sub-graph, if the instance is the same object as the klass mirror.
+  // Don't walk the references from the mirror object. The Klass of the
+  // mirror object is added to the klass dependency list.
   if (java_lang_Class::is_instance(orig_obj)) {
-    log_error(cds, heap)("(%d) Unknown java.lang.Class object is in the archived sub-graph", level);
-    vm_exit(1);
+    // During the walk for checking the subgraphs, check_reachable_objects_from
+    // makes sure only archived mirror objects are allowed for j.l.Class
+    // instances.
+    assert((java_lang_Class::as_Klass(orig_obj) != NULL &&
+            java_lang_Class::as_Klass(orig_obj)->java_mirror() == orig_obj) ||
+           java_lang_Class::is_primitive(orig_obj),
+           "must be mirror");
+    is_mirror = true;
   }
 
   oop archived_obj = find_archived_heap_object(orig_obj);
@@ -628,6 +767,7 @@ oop HeapShared::archive_reachable_objects_from(int level,
 
   bool record_klasses_only = (archived_obj != NULL);
   if (archived_obj == NULL) {
+    assert(!is_mirror, "Mirror object must be archived already");
     ++_num_new_archived_objs;
     archived_obj = archive_heap_object(orig_obj, THREAD);
     if (archived_obj == NULL) {
@@ -650,16 +790,38 @@ oop HeapShared::archive_reachable_objects_from(int level,
     }
   }
 
+  // Add the archived object's klass type to the subgraph dependency klass list.
   assert(archived_obj != NULL, "must be");
   Klass *orig_k = orig_obj->klass();
   Klass *relocated_k = archived_obj->klass();
   subgraph_info->add_subgraph_object_klass(orig_k, relocated_k);
 
-  WalkOopAndArchiveClosure walker(level, is_closed_archive, record_klasses_only,
-                                  subgraph_info, orig_obj, archived_obj, THREAD);
-  orig_obj->oop_iterate(&walker);
-  if (is_closed_archive && orig_k->is_instance_klass()) {
-    check_closed_archive_heap_region_object(InstanceKlass::cast(orig_k), THREAD);
+  if (!is_mirror) {
+    // Walk all references in the object and archive.
+    WalkOopAndArchiveClosure walker(level, is_closed_archive, record_klasses_only,
+                                    false /* check_preservable_only false */,
+                                    subgraph_info, orig_obj, archived_obj, THREAD);
+    orig_obj->oop_iterate(&walker);
+    if (is_closed_archive && orig_k->is_instance_klass()) {
+      check_closed_archive_heap_region_object(InstanceKlass::cast(orig_k), THREAD);
+    }
+  } else {
+    // This is an archived mirror object. No need to walk the mirror:
+    // - All non-static fields in archived mirrors are cleared;
+    // - Any of the non-preservable static fields in archived mirrors are reset
+    //   to the default values by java_lang_Class::process_archived_mirror;
+    // - All preservable static fields in both partially pre-initialized (only
+    //   some static fields are initialized and preserved) and fully
+    //   pre-initialized class mirrors are handled explicitly. See
+    //   archive_preservable_static_field_subgraphs() and
+    //   archive_preservable_klass_static_fields_subgraphs();
+    // - Preserved static fields in archived mirrors are handled by
+    //   initialize_from_archived_subgraph() at runtime during the corresponding
+    //   class' initialization time.
+    Klass *orig_as_k = java_lang_Class::as_Klass(orig_obj);
+    log_debug(cds, heap)("Archived %s mirror object" PTR_FORMAT " => " PTR_FORMAT,
+        orig_as_k == NULL ? "primitive type" : orig_as_k->external_name(),
+        p2i(orig_obj), p2i(archived_obj));
   }
   return archived_obj;
 }
@@ -671,9 +833,10 @@ oop HeapShared::archive_reachable_objects_from(int level,
 // Sub-graph archiving restrictions (current):
 //
 // - All classes of objects in the archived sub-graph (including the
-//   entry class) must be boot class only.
-// - No java.lang.Class instance (java mirror) can be included inside
-//   an archived sub-graph. Mirror can only be the sub-graph entry object.
+//   entry class) must be class loaded by the builtin class loaders.
+// - No non-mirror java.lang.Class instance can be included inside
+//   an archived sub-graph. Mirrors can be sub-graphs' entry objects,
+//   and can be included in sub-graphs.
 //
 // The Java heap object sub-graph archiving process (see
 // WalkOopAndArchiveClosure):
@@ -698,18 +861,24 @@ oop HeapShared::archive_reachable_objects_from(int level,
 // for loading and initialzing before any object in the archived graph can
 // be accessed at runtime.
 //
-void HeapShared::archive_reachable_objects_from_static_field(InstanceKlass *k,
-                                                             const char* klass_name,
-                                                             int field_offset,
-                                                             const char* field_name,
-                                                             bool is_closed_archive,
-                                                             TRAPS) {
+// For classes that are not annotated with @Preserve but with @Preserve
+// annotated static fields, 'is_partial_pre_init' is true. References to
+// those archived field values are stored separately in KlassSubGraphInfo
+// records and are not preserved with the corresponding mirror objects.
+//
+oop HeapShared::archive_reachable_objects_from_static_field(InstanceKlass *k,
+                                                            const char* klass_name,
+                                                            int field_offset,
+                                                            const char* field_name,
+                                                            bool is_closed_archive,
+                                                            bool is_partial_pre_init,
+                                                            TRAPS) {
   assert(DumpSharedSpaces, "dump time only");
-  assert(k->is_shared_boot_class(), "must be boot class");
+  assert(k->shared_classpath_index() >= 0, "must be BUILTIN type");
 
   oop m = k->java_mirror();
 
-  KlassSubGraphInfo* subgraph_info = get_subgraph_info(k);
+  KlassSubGraphInfo* subgraph_info = get_subgraph_info(k, is_partial_pre_init);
   oop f = m->obj_field(field_offset);
 
   log_debug(cds, heap)("Start archiving from: %s::%s (" PTR_FORMAT ")", klass_name, field_name, p2i(f));
@@ -722,23 +891,37 @@ void HeapShared::archive_reachable_objects_from_static_field(InstanceKlass *k,
     }
 
     oop af = archive_reachable_objects_from(1, subgraph_info, f,
-                                            is_closed_archive, CHECK);
+                                            is_closed_archive, CHECK_NULL);
 
     if (af == NULL) {
       log_error(cds, heap)("Archiving failed %s::%s (some reachable objects cannot be archived)",
                            klass_name, field_name);
     } else {
-      // Note: the field value is not preserved in the archived mirror.
-      // Record the field as a new subGraph entry point. The recorded
-      // information is restored from the archive at runtime.
-      subgraph_info->add_subgraph_entry_field(field_offset, af, is_closed_archive);
-      log_info(cds, heap)("Archived field %s::%s => " PTR_FORMAT, klass_name, field_name, p2i(af));
+      if (is_partial_pre_init) {
+        // Note: the field value is not preserved in the archived mirror.
+        // Record the field as a new subGraph entry point. The recorded
+        // information is restored from the archive at runtime.
+        subgraph_info->add_subgraph_entry_field(field_offset, af,
+                                                is_closed_archive);
+        log_info(cds, heap, subgraphinfo)(
+          "Recorded subgraph entry field (class partial pre-init) %s::%s",
+          klass_name, field_name);
+      }
+      log_info(cds, heap)("Archived field %s::%s => " PTR_FORMAT,
+                          klass_name, field_name, p2i(af));
+      return af;
     }
   } else {
     // The field contains null, we still need to record the entry point,
     // so it can be restored at runtime.
-    subgraph_info->add_subgraph_entry_field(field_offset, NULL, false);
+    if (is_partial_pre_init) {
+      subgraph_info->add_subgraph_entry_field(field_offset, NULL, false);
+      log_info(cds, heap, subgraphinfo)(
+        "Recorded subgraph entry field (class partial pre-init) %s::%s, "
+        "value is NULL", klass_name, field_name);
+    }
   }
+  return NULL;
 }
 
 #ifndef PRODUCT
@@ -763,7 +946,7 @@ class VerifySharedOopClosure: public BasicOopIterateClosure {
 
 void HeapShared::verify_subgraph_from_static_field(InstanceKlass* k, int field_offset) {
   assert(DumpSharedSpaces, "dump time only");
-  assert(k->is_shared_boot_class(), "must be boot class");
+  assert(k->shared_classpath_index() >= 0, "must be BUILTIN type");
 
   oop m = k->java_mirror();
   oop f = m->obj_field(field_offset);
@@ -813,7 +996,7 @@ void HeapShared::verify_reachable_objects_from(oop obj, bool is_archived) {
 }
 #endif
 
-HeapShared::SeenObjectsTable* HeapShared::_seen_objects_table = NULL;
+HeapShared::ObjectsTable* HeapShared::_seen_objects_table = NULL;
 int HeapShared::_num_new_walked_objs;
 int HeapShared::_num_new_archived_objs;
 int HeapShared::_num_old_recorded_klasses;
@@ -839,12 +1022,18 @@ void HeapShared::start_recording_subgraph(InstanceKlass *k, const char* class_na
   init_seen_objects_table();
   _num_new_walked_objs = 0;
   _num_new_archived_objs = 0;
-  _num_old_recorded_klasses = get_subgraph_info(k)->num_subgraph_object_klasses();
+  Klass* relocated_k = MetaspaceShared::get_relocated_klass(k);
+  KlassSubGraphInfo* ksg = find_subgraph_info(relocated_k);
+  _num_old_recorded_klasses =
+    (ksg == NULL) ? 0 : ksg->num_subgraph_object_klasses();
 }
 
 void HeapShared::done_recording_subgraph(InstanceKlass *k, const char* class_name) {
-  int num_new_recorded_klasses = get_subgraph_info(k)->num_subgraph_object_klasses() -
-    _num_old_recorded_klasses;
+  Klass* relocated_k = MetaspaceShared::get_relocated_klass(k);
+  KlassSubGraphInfo* info = find_subgraph_info(relocated_k);
+
+  int num_new_recorded_klasses = (info == NULL) ? 0 :
+    info->num_subgraph_object_klasses() - _num_old_recorded_klasses;
   log_info(cds, heap)("Done recording subgraph(s) for archived fields in %s: "
                       "walked %d objs, archived %d new objs, recorded %d classes",
                       class_name, _num_new_walked_objs, _num_new_archived_objs,
@@ -852,10 +1041,12 @@ void HeapShared::done_recording_subgraph(InstanceKlass *k, const char* class_nam
 
   delete_seen_objects_table();
 
-  _num_total_subgraph_recordings ++;
-  _num_total_walked_objs      += _num_new_walked_objs;
-  _num_total_archived_objs    += _num_new_archived_objs;
-  _num_total_recorded_klasses +=  num_new_recorded_klasses;
+  if (info != NULL) {
+    _num_total_subgraph_recordings ++;
+    _num_total_walked_objs      += _num_new_walked_objs;
+    _num_total_archived_objs    += _num_new_archived_objs;
+    _num_total_recorded_klasses +=  num_new_recorded_klasses;
+  }
 }
 
 class ArchivableStaticFieldFinder: public FieldClosure {
@@ -879,18 +1070,18 @@ public:
   int offset()     { return _offset; }
 };
 
-void HeapShared::init_subgraph_entry_fields(ArchivableStaticFieldInfo fields[],
-                                            int num, Thread* THREAD) {
-  if (!PreInitializeArchivedClass) {
+void HeapShared::initialize_preservable_static_field_infos(Thread* THREAD) {
+  if (_preservable_static_fields == NULL) {
     return;
   }
 
-  for (int i = 0; i < num; i++) {
-    ArchivableStaticFieldInfo* info = &fields[i];
-    TempNewSymbol klass_name =  SymbolTable::new_symbol(info->klass_name, THREAD);
-    TempNewSymbol field_name =  SymbolTable::new_symbol(info->field_name, THREAD);
+  assert(PreInitializeArchivedClass,
+         "should has no preservable static fields when PreInitializeArchivedClass is false");
 
-    Klass* k = SystemDictionary::resolve_or_null(klass_name, THREAD);
+  for (int i = 0; i < _preservable_static_fields->length(); i++) {
+    PreservableStaticFieldInfo* info = _preservable_static_fields->at(i);
+
+    Klass* k = SystemDictionary::resolve_or_null(info->klass_name(), THREAD);
     assert(k != NULL && !HAS_PENDING_EXCEPTION, "class must exist");
     InstanceKlass* ik = InstanceKlass::cast(k);
     assert(InstanceKlass::cast(ik)->is_shared_boot_class(),
@@ -898,33 +1089,28 @@ void HeapShared::init_subgraph_entry_fields(ArchivableStaticFieldInfo fields[],
     ik->initialize(THREAD);
     guarantee(!HAS_PENDING_EXCEPTION, "exception in initialize");
 
-    ArchivableStaticFieldFinder finder(ik, field_name);
+    ArchivableStaticFieldFinder finder(ik, info->field_name());
     ik->do_local_static_fields(&finder);
     assert(finder.found(), "field must exist");
 
-    info->klass = ik;
-    info->offset = finder.offset();
+    info->set_klass(ik);
+    info->set_offset(finder.offset());
   }
 }
 
-void HeapShared::init_subgraph_entry_fields(Thread* THREAD) {
-  _dump_time_subgraph_info_table = new (ResourceObj::C_HEAP, mtClass)DumpTimeKlassSubGraphInfoTable();
+void HeapShared::initialize_subgraph_entry_fields(Thread* THREAD) {
+  _dump_time_subgraph_info_table =
+    new (ResourceObj::C_HEAP, mtClass)DumpTimeKlassSubGraphInfoTable();
 
-  init_subgraph_entry_fields(closed_archive_subgraph_entry_fields,
-                             num_closed_archive_subgraph_entry_fields,
-                             THREAD);
-  init_subgraph_entry_fields(open_archive_subgraph_entry_fields,
-                             num_open_archive_subgraph_entry_fields,
-                             THREAD);
+  // Initialize classes with any static fields annotated with @Preserve.
+  initialize_preservable_static_field_infos(THREAD);
 }
 
-void HeapShared::archive_object_subgraphs(ArchivableStaticFieldInfo fields[],
-                                          int num, bool is_closed_archive,
-                                          Thread* THREAD) {
-  if (!PreInitializeArchivedClass) {
-    return;
-  }
-
+// Archive all individual static fields that are annotated with @Preserve.
+// The containing classes are not annotated with @Preserve and the remaining
+// static fields within those classes are not archived. As a result, the
+// archived containing classes are partially pre-initialized.
+void HeapShared::archive_preservable_static_field_subgraphs(Thread* THREAD) {
   _num_total_subgraph_recordings = 0;
   _num_total_walked_objs = 0;
   _num_total_archived_objs = 0;
@@ -938,42 +1124,668 @@ void HeapShared::archive_object_subgraphs(ArchivableStaticFieldInfo fields[],
   //     At runtime, these classes are initialized before X's archived fields
   //     are restored by HeapShared::initialize_from_archived_subgraph().
   int i;
-  for (i = 0; i < num; ) {
-    ArchivableStaticFieldInfo* info = &fields[i];
-    const char* klass_name = info->klass_name;
-    start_recording_subgraph(info->klass, klass_name);
+  int len = _preservable_static_fields->length();
+  for (i = 0; i < len;) {
+    PreservableStaticFieldInfo* info = _preservable_static_fields->at(i);
+    // Skip any fields that are found not preservable during the subgraph
+    // checking phase.
+    if (info->can_preserve()) {
+      assert(info->klass() != NULL, "sanity");
+      Symbol* klass_name = info->klass_name();
+      const char* klass_name_str = klass_name->as_C_string();
+      start_recording_subgraph(info->klass(), klass_name_str);
 
-    // If you have specified consecutive fields of the same klass in
-    // fields[], these will be archived in the same
-    // {start_recording_subgraph ... done_recording_subgraph} pass to
-    // save time.
-    for (; i < num; i++) {
-      ArchivableStaticFieldInfo* f = &fields[i];
-      if (f->klass_name != klass_name) {
-        break;
+      // Archive all static fields from the same class together.
+      for (; i < len; i++) {
+        PreservableStaticFieldInfo* f = _preservable_static_fields->at(i);
+        if (f->klass_name() != klass_name) {
+          break;
+        }
+        if (info->can_preserve()) {
+          archive_reachable_objects_from_static_field(f->klass(),
+                                                      klass_name_str,
+                                                      f->offset(),
+                                                      f->field_name()->as_C_string(),
+                                                      false,
+                                                      true, CHECK);
+        }
       }
-      archive_reachable_objects_from_static_field(f->klass, f->klass_name,
-                                                  f->offset, f->field_name,
-                                                  is_closed_archive, CHECK);
+      done_recording_subgraph(info->klass(), klass_name_str);
+    } else {
+      i ++; // Skip the one that cannot be preserved.
     }
-    done_recording_subgraph(info->klass, klass_name);
   }
 
-  log_info(cds, heap)("Archived subgraph records in %s archive heap region = %d",
-                      is_closed_archive ? "closed" : "open",
+  log_info(cds, heap)("Archived subgraph records in open archive heap region = %d",
                       _num_total_subgraph_recordings);
   log_info(cds, heap)("  Walked %d objects", _num_total_walked_objs);
   log_info(cds, heap)("  Archived %d objects", _num_total_archived_objs);
   log_info(cds, heap)("  Recorded %d klasses", _num_total_recorded_klasses);
 
 #ifndef PRODUCT
-  for (int i = 0; i < num; i++) {
-    ArchivableStaticFieldInfo* f = &fields[i];
-    verify_subgraph_from_static_field(f->klass, f->offset);
+  for (int i = 0; i < _preservable_static_fields->length(); i++) {
+    PreservableStaticFieldInfo* f = _preservable_static_fields->at(i);
+    if (f->can_preserve() && f->klass() != NULL) {
+      verify_subgraph_from_static_field(f->klass(), f->offset());
+    }
   }
   log_info(cds, heap)("  Verified %d references", _num_total_verifications);
 #endif
 }
+
+//////////////////////////////////////////////////////////////////////////
+//
+// Support for pre-initializing and archiving classes with @Preserve annotation.
+//
+// A class annotated with @Preserve is initialized at dump time. All static
+// fields within the class are preserved in the archive. For each archived
+// static field, the complete graph of reachable objects is copied into the
+// archive heap region and archived.
+//
+// At runtime, when the class is initialized, all preserved values
+// are retrieved from the archive and installed into the static fields. The
+// execution of <clinit> is skipped if the archived static fields are
+// successfully installed.
+//
+// Following is the overview of the related dump time procedure:
+//
+// 1) Initialize classes annotated with @Preserve.
+// 2) Remove unshareable info in archivable classes (also reset the related
+//    InstanceKlass _init_states to 'allocated'.
+// 3) Archive/relocate meta-objects.
+// 4) Archive mirror objects. All non-static fields in archived mirrors are
+//    cleared. All local static fields in classes without @Preserve are reset
+//    to the default values.
+// 5) Check if subgraphs reachable from static fields are preservable. The
+//    local static fields in a class with @Preserve is reset to the default
+//    values if PreservableKlassChecker finds any static fields cannot be
+//    preserved.
+// 6) Archive all preservable subgraphs.
+//
+///////////////////////////////////////////////////////////////////////////
+
+// Initial size for _preservable_static_fields list at Google scale
+const static int INITIAL_LIST_SIZE = 200000;
+
+bool HeapShared::_can_add_preserve_klasses = true;
+HeapShared::ObjectsTable* HeapShared::_not_preservable_object_cache = NULL;
+GrowableArray<PreservableStaticFieldInfo*>* HeapShared::_preservable_static_fields = NULL;
+// A list of preservable classes.
+HeapShared::PreInitializedPreservableKlasses* HeapShared::_preservable_klasses = NULL;
+
+// Closure for checking if a subgraph referenced from a reference type
+// static field is preservable. Please see more details in comments above
+// HeapShared::check_reachable_objects_from().
+class StaticFieldChecker: public FieldClosure {
+ private:
+  InstanceKlass* _ik;
+  bool _strict;
+  oop  _mirror;
+  bool _all_fields_preservable;
+  Thread* _thread;
+
+ public:
+  StaticFieldChecker(InstanceKlass* ik, bool strict, Thread* thread) :
+    _ik(ik), _strict(strict), _all_fields_preservable(true),
+    _thread(thread) {
+    _mirror = ik->java_mirror();
+  }
+
+  void do_field(fieldDescriptor* fd) {
+    assert(DumpSharedSpaces, "dump time only");
+    if (!_all_fields_preservable) {
+      return;
+    }
+
+    BasicType ft = fd->field_type();
+    switch (ft) {
+      case T_ARRAY:
+      case T_OBJECT: {
+        ResourceMark rm;
+        log_trace(cds, heap)(
+                  "Checking static field %s.%s(%s)",
+                  _ik->external_name(),
+                  fd->name()->as_C_string(),
+                  fd->signature()->as_C_string());
+
+        oop o = _mirror->obj_field(fd->offset());
+        if (!CompressedOops::is_null(o)) {
+          if (_strict) {
+            if (!(fd->is_final()) || !(fd->access_flags().is_stable())) {
+              if (!java_lang_String::is_instance(o)) {
+                ResourceMark rm;
+                _all_fields_preservable = false;
+                log_trace(cds, heap)(
+                  "Static field %s.%s(%s) is not final or stable. "
+                  "Class cannot be preserved.",
+                  _ik->external_name(),
+                  fd->name()->as_C_string(),
+                  fd->signature()->as_C_string());
+                break;
+              }
+            }
+          }
+          _all_fields_preservable =
+            HeapShared::check_reachable_objects_from(1, o, _thread);
+        }
+        break;
+      }
+      default:
+        break;
+     }
+  }
+
+  bool all_fields_preservable() {
+    return _all_fields_preservable;
+  }
+};
+
+class StaticFieldArchiver: public FieldClosure {
+  InstanceKlass* _ik;
+  oop _archived_mirror;
+  Thread* _thread;
+public:
+  StaticFieldArchiver(InstanceKlass* ik, oop archived_mirror,
+                      Thread* thread) :
+    _ik(ik), _archived_mirror(archived_mirror), _thread(thread) {}
+
+  virtual void do_field(fieldDescriptor* fd) {
+    BasicType ft = fd->field_type();
+    if (ft == T_ARRAY || ft == T_OBJECT) {
+      int field_offset = fd->offset();
+      oop archived_v = HeapShared::archive_reachable_objects_from_static_field(
+                         _ik, _ik->external_name(), field_offset,
+                         fd->name()->as_klass_external_name(),
+                         false, false, _thread);
+      _archived_mirror->obj_field_put_raw(field_offset, archived_v);
+    }
+  }
+};
+
+void HeapShared::set_can_preserve(InstanceKlass *ik, bool is_annotated) {
+  if (DumpSharedSpaces && PreInitializeArchivedClass &&
+      _can_add_preserve_klasses) {
+    ik->set_can_preserve();
+    ResourceMark rm;
+    log_info(preinit)("Set can_preserve for class %s(" PTR_FORMAT "), %s",
+                      ik->external_name(), p2i(ik),
+                      is_annotated ? "with @Preserve annotation" :
+                                     "no <clinit> or static field");
+  }
+}
+
+void HeapShared::add_preservable_class(InstanceKlass *ik) {
+  if (!DumpSharedSpaces || !_can_add_preserve_klasses) {
+    return;
+  }
+
+  assert(!ik->is_anonymous(), "Anonymous klass cannot be preserved");
+
+  if (_preservable_klasses == NULL) {
+    _preservable_klasses =
+      new (ResourceObj::C_HEAP, mtClass)PreInitializedPreservableKlasses();
+  }
+  _preservable_klasses->put(ik, true);
+  ResourceMark rm;
+  log_info(preinit)("Add preservable class %s(" PTR_FORMAT ")",
+                    ik->external_name(), p2i(ik));
+}
+
+// Called by ClassFileParser when a static field with @Preserve is processed.
+void HeapShared::add_preservable_static_field(Symbol* class_name,
+                                              Symbol* field_name) {
+  if (!DumpSharedSpaces || !PreInitializeArchivedClass) {
+    return;
+  }
+
+  if (_preservable_static_fields == NULL) {
+    _preservable_static_fields =
+      new(ResourceObj::C_HEAP, mtClass)GrowableArray<PreservableStaticFieldInfo*>(
+          INITIAL_LIST_SIZE, true);
+  }
+
+  PreservableStaticFieldInfo* field_info =
+    new PreservableStaticFieldInfo(class_name,field_name);
+  _preservable_static_fields->append(field_info);
+
+  if (log_is_enabled(Debug, cds, heap)) {
+    log_debug(cds, heap)("Found @Preserve annotated field %s.%s",
+                         class_name->as_C_string(), field_name->as_C_string());
+  }
+}
+
+// This is called when archiving mirrors after metadata relocation. The
+// Klasses are from MetaspaceShared::collected_klasses(), which are already
+// relocated at this point.
+bool HeapShared::reset_klass_statics(Klass *k) {
+  ResourceMark rm;
+  if (k->is_instance_klass()) {
+    InstanceKlass *ik = InstanceKlass::cast(k);
+    // Support classes from BUILTIN class loaders.
+    if (ik->shared_classpath_index() >= 0 &&
+        ik->can_preserve()) {
+      log_info(cds, heap)("Preserve static fields for %s", k->external_name());
+      return false;
+    }
+  }
+  log_info(cds, heap)("Reset static fields for %s", k->external_name());
+  return true;
+}
+
+void HeapShared::initialize_preservable_klass(InstanceKlass *ik,
+                                              Thread* THREAD) {
+  if (!PreInitializeArchivedClass) {
+    return;
+  }
+
+  if (ik->can_preserve()) {
+    // Support all builtin class loaders
+    if (ik->shared_classpath_index() >= 0) {
+      ResourceMark rm(THREAD);
+      log_info(cds, heap)("Initializing preservable class %s(" PTR_FORMAT ")",
+                          ik->external_name(), p2i(ik));
+      ik->initialize(THREAD);
+      if (THREAD->has_pending_exception()) {
+        THREAD->clear_pending_exception();
+        ik->clear_can_preserve();
+        return;
+      }
+      assert(ik->is_initialized(), "must be initialized");
+    } else {
+      ik->clear_can_preserve();
+    }
+  }
+}
+
+class PreservableKlassChecker {
+  Thread* _thread;
+ public:
+  PreservableKlassChecker(Thread* thread) :
+    _thread(thread) {}
+
+  bool do_entry(Klass *k, bool v) {
+    if (!k->can_preserve()) {
+      return true;
+    }
+
+    if (k->is_instance_klass()) {
+      InstanceKlass* ik = InstanceKlass::cast(k);
+
+      // Support classes for builtin loaders.
+      if (ik->shared_classpath_index() >= 0) {
+        ResourceMark rm(_thread);
+        log_debug(cds, heap)("Checking if class %s(" PTR_FORMAT ") is "
+                             "preservable", ik->external_name(), p2i(ik));
+        HeapShared::init_seen_objects_table();
+        StaticFieldChecker checker(ik, false, _thread);
+        ik->do_local_static_fields(&checker);
+        if (checker.all_fields_preservable()) {
+          log_info(cds, heap)("Class %s(" PTR_FORMAT ") is preservable",
+                              ik->external_name(), p2i(ik));
+        } else {
+          ik->clear_can_preserve();
+          // Reset all static fields in the archived mirror. The instance fields
+          // in the mirror is already reset by
+          // java_lang_Class::process_archived_mirror().
+          oop m = ik->java_mirror();
+          if (!java_lang_Class::is_primitive(m)) {
+            oop archived_m = HeapShared::find_archived_heap_object(m);
+            java_lang_Class::reset_mirror_static_fields(ik, archived_m, _thread);
+          }
+          log_info(cds, heap)("Class %s(" PTR_FORMAT ") is not preservable",
+                              ik->external_name(), p2i(ik));
+        }
+        HeapShared::delete_seen_objects_table();
+      }
+    }
+    return true;
+  }
+};
+
+void HeapShared::check_preservable_klasses_and_fields(Thread* THREAD) {
+  // The temporary cache is used during the subgraph object checking to
+  // avoid walking any non-preservable objects more than once.
+  _not_preservable_object_cache =
+    new (ResourceObj::C_HEAP, mtClass)ObjectsTable();
+
+  check_preservable_static_fields(THREAD);
+  check_preservable_klasses(THREAD);
+
+  delete _not_preservable_object_cache;
+  _not_preservable_object_cache = NULL;
+}
+
+// Check if the static fields in classes annotated with @Preserve can be
+// archived(preserved). See StaticFieldChecker for details. If any of the
+// static fields in a class cannot be preserved, the _can_preserve flag is
+// set to false in its Klass' _shared_class_flags.
+void HeapShared::check_preservable_klasses(Thread* THREAD) {
+  // Don't add any new class to the preservable classes at this point.
+  _can_add_preserve_klasses = false;
+
+  PreservableKlassChecker checker(THREAD);
+  _preservable_klasses->iterate(&checker);
+}
+
+// Check individual static fields annotated with @Preserve. If a
+// static field cannot be preserved, the corresponding
+// PreservableStaticFieldInfo._can_preserve flag is set to false.
+//
+// Currently only support static fields in boot classes.
+// TODO(b/168823639): Support for all builtin loaders.
+void HeapShared::check_preservable_static_fields(Thread* THREAD) {
+  if (_preservable_static_fields == NULL) {
+    return;
+  }
+
+  for (int i = 0; i < _preservable_static_fields->length(); i++) {
+    PreservableStaticFieldInfo* info = _preservable_static_fields->at(i);
+    assert(info->can_preserve(), "can_preserve is already false");
+    InstanceKlass* ik = info->klass();
+    assert(ik != NULL, "class must exist");
+    assert(ik->is_shared_boot_class(), "Only support boot classes");
+    oop m = ik->java_mirror();
+    oop o = m->obj_field(info->offset());
+    HeapShared::init_seen_objects_table();
+    if (!check_reachable_objects_from(1, o, THREAD)) {
+      info->set_can_preserve(false);
+    }
+    HeapShared::delete_seen_objects_table();
+  }
+}
+
+// Checks if an object within a subgraph can be preserved. An object should
+// not be preserved if it is:
+//
+// - a Java object whose class type is anonymous class
+// - a j.l.Class instance that is not a Klass mirror
+// - a j.l.ProtectionDomain instance
+// - an instance of j.l.ClassLoader or any of the subclasses
+// - a j.l.Runnable instance
+//
+// A static field value should not be preserved in the archive if its subgraph
+// contains any of the above objects.
+bool HeapShared::check_reachable_objects_from(int level,
+                                              oop obj,
+                                              TRAPS) {
+  assert(obj != NULL, "must be");
+
+  bool is_preservable = true;
+  bool walk_references = true;
+  Klass *k = obj->klass();
+  log_debug(cds, heap)("(%d) Checking if %s object (" PTR_FORMAT ") is "
+                       "preservable", level, k->external_name(), p2i(obj));
+
+  // It is safe to archive the object if it is locked as
+  // HeapShared::archive_heap_object resets markword.
+  if (!obj->is_unlocked()) {
+    log_debug(cds, heap)(
+              "(%d) Object(%s) is locked. Can be preserved.",
+              level, k->external_name());
+  }
+
+  if (not_preservable_object_cache()->get(obj)) {
+    is_preservable = false;
+    log_debug(cds, heap)(
+              "(%d) Object(%s) is already in not_preservable_object_cache.",
+              level, k->external_name());
+    return false;
+  }
+
+  if (k->is_instance_klass()) {
+    InstanceKlass *ik = InstanceKlass::cast(k);
+    if (ik->is_anonymous()) {
+      is_preservable = false;
+      log_debug(cds, heap)(
+                "(%d) Object class is anonymous: %s. Cannot be preserved.",
+                level, k->external_name());
+    }
+
+    if (java_lang_Class::is_instance(obj)) {
+      // This is a java.lang.Class instance. A java.lang.Class instance can be
+      // included in archived subgraphs if:
+      //
+      // It's the same object as the klass mirror, and the obj Klass type is
+      // not an anonymous class.
+      Klass* mirror_k = java_lang_Class::as_Klass(obj);
+      if (mirror_k == NULL){
+        // Check if it is a basic type mirror. Need to use the archived object,
+        // as basic type mirrors in Universe::_mirrors[] are already relocated
+        // at this point.
+        if (Universe::is_basic_type_mirror(find_archived_heap_object(obj))) {
+          walk_references = false;
+          log_debug(cds, heap)(
+            "(%d) java.lang.Class object (" PTR_FORMAT ") is primitive type "
+            "mirror. Can be included in the archived sub-graph.",
+            level, p2i(obj));
+        } else {
+          is_preservable = false;
+          log_debug(cds, heap)(
+            "(%d) java.lang.Class object (" PTR_FORMAT ") is not mirror."
+            "Cannot be preserved.", level, p2i(obj));
+        }
+      } else if (mirror_k->is_instance_klass()) {
+        // The object's Klass type is an InstanceKlass.
+        if (!InstanceKlass::cast(mirror_k)->is_anonymous()) {
+          if (obj == mirror_k->java_mirror() &&
+              HeapShared::find_archived_heap_object(obj) != NULL) {
+            // This is an archived mirror object. Don't follow
+            // the references from mirror.
+            walk_references = false;
+            assert(obj == mirror_k->java_mirror(), "mirror object is different");
+            log_debug(cds, heap)(
+              "(%d) java.lang.Class object (" PTR_FORMAT ") (%s) is a mirror object. "
+              "Can be included in the archived sub-graph.",
+              level, p2i(obj), java_lang_Class::as_external_name(obj));
+          } else {
+            // The java.lang.Class instance is not a mirror and cannot be
+            // included in an archived object sub-graph since it contains
+            // references to ClassLoader object.
+            is_preservable = false;
+            log_debug(cds, heap)(
+              "(%d) java.lang.Class object (%s) Klass is not archived mirror."
+              "Cannot be preserved.",
+              level, java_lang_Class::as_external_name(obj));
+          }
+        } else {
+          // Anonymous klasses are not archived.
+          is_preservable = false;
+          log_debug(cds, heap)(
+            "(%d) java.lang.Class object (%s) Klass is anonymous."
+            "Cannot be preserved.",
+            level, java_lang_Class::as_external_name(obj));
+        }
+      } else if (mirror_k->is_array_klass()) {
+        // The array klass field at that the _array_klass_offset must not be
+        // NULL.
+        if (java_lang_Class::array_klass_acquire(obj) != NULL) {
+          // This is a mirror object. Don't follow the references from mirror.
+          walk_references = false;
+          assert(obj == mirror_k->java_mirror(), "mirror object is different");
+          log_debug(cds, heap)(
+            "(%d) java.lang.Class object " PTR_FORMAT "(%s) is an array klass "
+            "mirror object. Can be included in the archived sub-graph.",
+            level, p2i(obj), java_lang_Class::as_external_name(obj));
+        }
+      }
+    } else if (java_lang_ClassLoader::is_instance(obj)) {
+      is_preservable = false;
+      log_debug(cds, heap)(
+        "(%d) java.lang.ClassLoader object is in the archived sub-graph. "
+        "Cannot be preserved.", level);
+    } else if (ik == SystemDictionary::ProtectionDomain_klass()) {
+      is_preservable = false;
+      log_debug(cds, heap)(
+        "(%d) java.lang.ProtectionDomain object is in the archived sub-graph. "
+        "Cannot be preserved.", level);
+    } else if (ik->implements_interface(SystemDictionary::Runnable_klass())) {
+      is_preservable = false;
+      log_debug(cds, heap)(
+        "(%d) Object(%s) is Runnable. "
+        "Cannot be preserved.", level, k->external_name());
+    }
+  }
+
+  // Now follow the references and walk the rest of the subgraph.
+  if (!has_been_seen_during_subgraph_recording(obj)) {
+    set_has_been_seen_during_subgraph_recording(obj);
+
+    if (is_preservable) {
+      if (walk_references) {
+        WalkOopAndArchiveClosure walker(level, false /* is_closed_region */,
+                                        false /* record_klasses_only */,
+                                        true  /* check_preservable_only */,
+                                        NULL, obj, NULL, THREAD);
+        obj->oop_iterate(&walker);
+        is_preservable = walker.is_preservable();
+      }
+    }
+  }
+
+  if (!is_preservable) {
+    // Propagate the state to the current object if any of the objects within
+    // the current object's reachable subgraph is not preservable.
+    not_preservable_object_cache()->put(obj, true);
+    log_debug(cds, heap)(
+              "(%d) %s object subgraph contains not preservable object(s). "
+              "Cannot be preserved.",
+              level, k->external_name());
+  }
+  return is_preservable;
+}
+
+class PreservableKlassArchiver {
+  Thread* _thread;
+ public:
+  PreservableKlassArchiver(Thread* thread) : _thread(thread) {}
+
+  bool do_entry(Klass *k, bool v) {
+    if (k->can_preserve() && k->is_instance_klass()) {
+      // The InstanceKlass _init_state is already reset to 'loaded'.
+      InstanceKlass* ik = InstanceKlass::cast(k);
+      // Only support classes for BUILTIN class loader currently.
+      if (ik->shared_classpath_index() >= 0) {
+        ResourceMark rm(_thread);
+        const char* klass_name = ik->external_name();
+
+        log_info(cds, heap)("Archiving preservable class %s static fields",
+                            ik->external_name());
+
+        oop archived_mirror =
+          HeapShared::find_archived_heap_object(ik->java_mirror());
+        assert(archived_mirror != NULL, "No archived mirror object");
+
+        HeapShared::start_recording_subgraph(ik, klass_name);
+
+        StaticFieldArchiver archiver(ik, archived_mirror, _thread);
+        ik->do_local_static_fields(&archiver);
+
+        HeapShared::done_recording_subgraph(ik, klass_name);
+      }
+    }
+    return true;
+  }
+};
+
+// The current class can be set to
+// is_pre_initialized_without_dependency_class if all super types (except
+// j.l.Object) have is_pre_initialized_without_dependency_class flags.
+//
+// At runtime, a class with is_pre_initialized_without_dependency_class
+// flag can be set to fully_initialized state immediately after being
+// loaded and restored from the shared archive.
+bool HeapShared::set_pre_initialize_state(InstanceKlass *ik) {
+  if (!ik->can_preserve()) {
+    return false;
+  };
+
+  InstanceKlass *relocated_ik =
+    InstanceKlass::cast(MetaspaceShared::get_relocated_klass(ik));
+  if (relocated_ik->has_pre_initialized_flag()) {
+    return true;
+  }
+
+  ResourceMark rm;
+  // First process all super classes.
+  InstanceKlass *super_k = InstanceKlass::cast(ik->super());
+  if (super_k != SystemDictionary::Object_klass()) {
+    if (!set_pre_initialize_state(super_k) ||
+      MetaspaceShared::get_relocated_klass(super_k)->is_pre_initialized_with_dependency_class()) {
+      // The super class is not pre_initialized or its static initializer
+      // has dependency classes.
+      relocated_ik->set_is_pre_initialized_with_dependency_class();
+      log_info(preinit)(
+        "Set %s to is_pre_initialized_with_dependency_class",
+        ik->external_name());
+      return true;
+    }
+  }
+
+  // If we get here, all super classes (except j.l.Object) of the current
+  // class have is_pre_initialized_without_dependency_class flag set.
+
+  // Now process all local interfaces.
+  Array<Klass*>* local_interfaces = ik->local_interfaces();
+  if (local_interfaces != NULL) {
+    for (int idx = 0; idx < local_interfaces->length(); idx++) {
+      InstanceKlass *itf = InstanceKlass::cast(local_interfaces->at(idx));
+      if (!set_pre_initialize_state(itf) ||
+          MetaspaceShared::get_relocated_klass(itf)->is_pre_initialized_with_dependency_class()) {
+        // The super interface is not pre_initialized or its static
+        // initializer has dependency classes.
+        relocated_ik->set_is_pre_initialized_with_dependency_class();
+        log_info(preinit)(
+          "Set %s to is_pre_initialized_with_dependency_class",
+          ik->external_name());
+        return true;
+      }
+    }
+  }
+
+  // If we get here, all super classes (except j.l.Object) and super interfaces
+  // of the current class have is_pre_initialized_without_dependency_class flag
+  // set.
+
+  // Now process the current class.
+  KlassSubGraphInfo* info = HeapShared::get_subgraph_info(ik, false);
+  if (info->subgraph_object_klasses() == NULL ||
+      info->subgraph_object_klasses()->length() == 0) {
+    // Current class initializer has no dependency class.
+    relocated_ik->set_is_pre_initialized_without_dependency_class();
+    log_info(preinit)(
+      "Set %s to is_pre_initialized_without_dependency_class",
+      ik->external_name());
+  } else {
+    relocated_ik->set_is_pre_initialized_with_dependency_class();
+    log_info(preinit)(
+      "Set %s to is_pre_initialized_with_dependency_class",
+      ik->external_name());
+  }
+  return true;
+}
+
+class PreservableKlassStateClosure {
+ public:
+  PreservableKlassStateClosure() {}
+
+  bool do_entry(Klass *k, bool v) {
+    HeapShared::set_pre_initialize_state(InstanceKlass::cast(k));
+    return true;
+  }
+};
+
+void HeapShared::archive_preservable_klass_static_fields_subgraphs(Thread* THREAD) {
+  if (_preservable_klasses == NULL) {
+    return;
+  }
+  PreservableKlassArchiver archiver(THREAD);
+  _preservable_klasses->iterate(&archiver);
+
+  PreservableKlassStateClosure set_state;
+  _preservable_klasses->iterate(&set_state);
+}
+
+////////////////////////////////////////////////////////////////
 
 // At dump-time, find the location of all the non-null oop pointers in an archived heap
 // region. This way we can quickly relocate all the pointers without using

--- a/src/hotspot/share/memory/universe.hpp
+++ b/src/hotspot/share/memory/universe.hpp
@@ -317,6 +317,19 @@ class Universe: AllStatic {
     assert((uint)t < T_VOID+1, "range check");
     return check_mirror(_mirrors[t]);
   }
+
+  static bool is_basic_type_mirror(oop m) {
+    return (m == _mirrors[T_INT] ||
+            m == _mirrors[T_FLOAT] ||
+            m == _mirrors[T_DOUBLE] ||
+            m == _mirrors[T_BYTE] ||
+            m == _mirrors[T_BOOLEAN] ||
+            m == _mirrors[T_CHAR] ||
+            m == _mirrors[T_LONG] ||
+            m == _mirrors[T_SHORT] ||
+            m == _mirrors[T_VOID]);
+  }
+
   static oop      main_thread_group()                 { return _main_thread_group; }
   static void set_main_thread_group(oop group)        { _main_thread_group = group;}
 

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -385,7 +385,14 @@ void ConstantPool::remove_unshareable_info() {
   _flags |= (_on_stack | _is_shared);
   int num_klasses = 0;
   for (int index = 1; index < length(); index++) { // Index 0 is unused
-    assert(!tag_at(index).is_unresolved_klass_in_error(), "This must not happen during dump time");
+    // More <clinit> executions during dump time can cause more constant pool
+    // resolutions.
+    if (tag_at(index).is_unresolved_klass_in_error() ||
+        tag_at(index).is_method_handle_in_error()    ||
+        tag_at(index).is_method_type_in_error()      ||
+        tag_at(index).is_dynamic_constant_in_error()) {
+        tag_at_put(index, JVM_CONSTANT_UnresolvedClass);
+    }
     if (tag_at(index).is_klass()) {
       // This class was resolved as a side effect of executing Java code
       // during dump time. We need to restore it back to an UnresolvedClass,

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -547,7 +547,7 @@ public:
   Method* class_initializer() const;
 
   // set the class to initialized if no static initializer is present
-  void eager_initialize(Thread *thread);
+  void eager_initialize(ClassLoaderData* loader_data, Thread *thread);
 
   // reference type
   ReferenceType reference_type() const     { return (ReferenceType)_reference_type; }
@@ -1281,6 +1281,7 @@ private:
   void initialize_impl                           (TRAPS);
   void initialize_super_interfaces               (TRAPS);
   void eager_initialize_impl                     ();
+  void shared_class_pre_initialize_impl(ClassLoaderData* loader_data, TRAPS);
   /* jni_id_for_impl for jfieldID only */
   JNIid* jni_id_for_impl                         (int offset);
 

--- a/src/java.base/share/classes/java/lang/Byte.java
+++ b/src/java.base/share/classes/java/lang/Byte.java
@@ -44,6 +44,7 @@ import jdk.internal.misc.VM;
  * @see     java.lang.Number
  * @since   1.1
  */
+@jdk.internal.vm.annotation.Preserve
 public final class Byte extends Number implements Comparable<Byte> {
 
     /**
@@ -77,6 +78,7 @@ public final class Byte extends Number implements Comparable<Byte> {
         return Integer.toString((int)b, 10);
     }
 
+    @jdk.internal.vm.annotation.Preserve
     private static class ByteCache {
         private ByteCache() {}
 
@@ -86,8 +88,15 @@ public final class Byte extends Number implements Comparable<Byte> {
         static {
             final int size = -(-128) + 127 + 1;
 
+            // GOOGLE: With the general support for class and static field
+            //         pre-initialization, it no longer needs to call
+            //         VM.initializeFromArchive() explicitly at runtime to
+            //         load the archived value for fields annotated with
+            //         @Preserve. That allows application classes to take
+            //         advantage of the pre-initialization feature.
+            //
             // Load and use the archived cache if it exists
-            VM.initializeFromArchive(ByteCache.class);
+            //VM.initializeFromArchive(ByteCache.class);
             if (archivedCache == null || archivedCache.length != size) {
                 Byte[] c = new Byte[size];
                 byte value = (byte)-128;

--- a/src/java.base/share/classes/java/lang/Character.java
+++ b/src/java.base/share/classes/java/lang/Character.java
@@ -133,6 +133,7 @@ import jdk.internal.misc.VM;
  * @author  Ulf Zibis
  * @since   1.0
  */
+@jdk.internal.vm.annotation.Preserve
 public final
 class Character implements java.io.Serializable, Comparable<Character> {
     /**
@@ -7915,6 +7916,7 @@ class Character implements java.io.Serializable, Comparable<Character> {
         this.value = value;
     }
 
+    @jdk.internal.vm.annotation.Preserve
     private static class CharacterCache {
         private CharacterCache(){}
 
@@ -7924,8 +7926,15 @@ class Character implements java.io.Serializable, Comparable<Character> {
         static {
             int size = 127 + 1;
 
+            // GOOGLE: With the general support for class and static field
+            //         pre-initialization, it no longer needs to call
+            //         VM.initializeFromArchive() explicitly at runtime to
+            //         load the archived value for fields annotated with
+            //         @Preserve. That allows application classes to take
+            //         advantage of the pre-initialization feature.
+            //
             // Load and use the archived cache if it exists
-            VM.initializeFromArchive(CharacterCache.class);
+            //VM.initializeFromArchive(CharacterCache.class);
             if (archivedCache == null || archivedCache.length != size) {
                 Character[] c = new Character[size];
                 for (int i = 0; i < size; i++) {

--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -2899,6 +2899,7 @@ public final class Class<T> implements java.io.Serializable,
     /**
      * Atomic operations support.
      */
+    @jdk.internal.vm.annotation.Preserve
     private static class Atomic {
         // initialize Unsafe machinery here, since we need to call Class.class instance method
         // and have to avoid calling it in the static initializer of the Class class...
@@ -2938,6 +2939,7 @@ public final class Class<T> implements java.io.Serializable,
 
     // Reflection data caches various derived names and reflective members. Cached
     // values may be invalidated when JVM TI RedefineClasses() is called
+    @jdk.internal.vm.annotation.Preserve
     private static class ReflectionData<T> {
         volatile Field[] declaredFields;
         volatile Field[] publicFields;

--- a/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -2405,6 +2405,7 @@ public abstract class ClassLoader {
      * @see      ClassLoader
      * @since    1.2
      */
+    @jdk.internal.vm.annotation.Preserve(false)
     static class NativeLibrary {
         // the class from which the library is loaded, also indicates
         // the loader this native library belongs.

--- a/src/java.base/share/classes/java/lang/Double.java
+++ b/src/java.base/share/classes/java/lang/Double.java
@@ -46,6 +46,7 @@ import jdk.internal.HotSpotIntrinsicCandidate;
  * @author  Joseph D. Darcy
  * @since 1.0
  */
+@jdk.internal.vm.annotation.Preserve
 public final class Double extends Number implements Comparable<Double> {
     /**
      * A constant holding the positive infinity of type

--- a/src/java.base/share/classes/java/lang/Float.java
+++ b/src/java.base/share/classes/java/lang/Float.java
@@ -45,6 +45,7 @@ import jdk.internal.HotSpotIntrinsicCandidate;
  * @author  Joseph D. Darcy
  * @since 1.0
  */
+@jdk.internal.vm.annotation.Preserve
 public final class Float extends Number implements Comparable<Float> {
     /**
      * A constant holding the positive infinity of type

--- a/src/java.base/share/classes/java/lang/Integer.java
+++ b/src/java.base/share/classes/java/lang/Integer.java
@@ -56,6 +56,7 @@ import static java.lang.String.UTF16;
  * @author  Joseph D. Darcy
  * @since 1.0
  */
+@jdk.internal.vm.annotation.Preserve
 public final class Integer extends Number implements Comparable<Integer> {
     /**
      * A constant holding the minimum value an {@code int} can
@@ -1004,6 +1005,7 @@ public final class Integer extends Number implements Comparable<Integer> {
         static final int low = -128;
         static final int high;
         static final Integer[] cache;
+        @jdk.internal.vm.annotation.Preserve
         static Integer[] archivedCache;
 
         static {
@@ -1022,8 +1024,15 @@ public final class Integer extends Number implements Comparable<Integer> {
             }
             high = h;
 
+            // GOOGLE: With the general support for class and static field
+            //         pre-initialization, it no longer needs to call
+            //         VM.initializeFromArchive() explicitly at runtime to
+            //         load the archived value for fields annotated with
+            //         @Preserve. That allows application classes to take
+            //         advantage of the pre-initialization feature.
+            //
             // Load IntegerCache.archivedCache from archive, if possible
-            VM.initializeFromArchive(IntegerCache.class);
+            //VM.initializeFromArchive(IntegerCache.class);
             int size = (high - low) + 1;
 
             // Use the archived cache if it exists and is large enough

--- a/src/java.base/share/classes/java/lang/Long.java
+++ b/src/java.base/share/classes/java/lang/Long.java
@@ -57,6 +57,7 @@ import static java.lang.String.UTF16;
  * @author  Joseph D. Darcy
  * @since   1.0
  */
+@jdk.internal.vm.annotation.Preserve
 public final class Long extends Number implements Comparable<Long> {
     /**
      * A constant holding the minimum value a {@code long} can
@@ -1145,6 +1146,7 @@ public final class Long extends Number implements Comparable<Long> {
         return Long.valueOf(parseLong(s, 10));
     }
 
+    @jdk.internal.vm.annotation.Preserve
     private static class LongCache {
         private LongCache() {}
 
@@ -1154,8 +1156,15 @@ public final class Long extends Number implements Comparable<Long> {
         static {
             int size = -(-128) + 127 + 1;
 
+            // GOOGLE: With the general support for class and static field
+            //         pre-initialization, it no longer needs to call
+            //         VM.initializeFromArchive() explicitly at runtime to
+            //         load the archived value for fields annotated with
+            //         @Preserve. That allows application classes to take
+            //         advantage of the pre-initialization feature.
+            //
             // Load and use the archived cache if it exists
-            VM.initializeFromArchive(LongCache.class);
+            //VM.initializeFromArchive(LongCache.class);
             if (archivedCache == null || archivedCache.length != size) {
                 Long[] c = new Long[size];
                 long value = -128;

--- a/src/java.base/share/classes/java/lang/Object.java
+++ b/src/java.base/share/classes/java/lang/Object.java
@@ -36,6 +36,7 @@ import jdk.internal.HotSpotIntrinsicCandidate;
  * @see     java.lang.Class
  * @since   1.0
  */
+/* TODO(b/170313595): @jdk.internal.vm.annotation.Preserve(false) */
 public class Object {
 
     private static native void registerNatives();

--- a/src/java.base/share/classes/java/lang/Short.java
+++ b/src/java.base/share/classes/java/lang/Short.java
@@ -43,6 +43,7 @@ import jdk.internal.misc.VM;
  * @see     java.lang.Number
  * @since   1.1
  */
+@jdk.internal.vm.annotation.Preserve
 public final class Short extends Number implements Comparable<Short> {
 
     /**
@@ -203,6 +204,7 @@ public final class Short extends Number implements Comparable<Short> {
         return valueOf(s, 10);
     }
 
+    @jdk.internal.vm.annotation.Preserve
     private static class ShortCache {
         private ShortCache() {}
 
@@ -212,8 +214,15 @@ public final class Short extends Number implements Comparable<Short> {
         static {
             int size = -(-128) + 127 + 1;
 
+            // GOOGLE: With the general support for class and static field
+            //         pre-initialization, it no longer needs to call
+            //         VM.initializeFromArchive() explicitly at runtime to
+            //         load the archived value for fields annotated with
+            //         @Preserve. That allows application classes to take
+            //         advantage of the pre-initialization feature.
+            //
             // Load and use the archived cache if it exists
-            VM.initializeFromArchive(ShortCache.class);
+            //VM.initializeFromArchive(ShortCache.class);
             if (archivedCache == null || archivedCache.length != size) {
                 Short[] c = new Short[size];
                 short value = -128;

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -121,7 +121,7 @@ import jdk.internal.vm.annotation.Stable;
  * @since   1.0
  * @jls     15.18.1 String Concatenation Operator +
  */
-
+@jdk.internal.vm.annotation.Preserve
 public final class String
     implements java.io.Serializable, Comparable<String>, CharSequence {
 
@@ -1215,6 +1215,7 @@ public final class String
      */
     public static final Comparator<String> CASE_INSENSITIVE_ORDER
                                          = new CaseInsensitiveComparator();
+    @jdk.internal.vm.annotation.Preserve
     private static class CaseInsensitiveComparator
             implements Comparator<String>, java.io.Serializable {
         // use serialVersionUID from JDK 1.2.2 for interoperability

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -89,6 +89,7 @@ import sun.security.util.SecurityConstants;
  *
  * @since   1.0
  */
+@jdk.internal.vm.annotation.Preserve(false)
 public final class System {
     /* Register the natives via the static initializer.
      *

--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -139,6 +139,7 @@ import jdk.internal.HotSpotIntrinsicCandidate;
  * @see     #stop()
  * @since   1.0
  */
+/* TODO(b/170313595): @jdk.internal.vm.annotation.Preserve(false) */
 public
 class Thread implements Runnable {
     /* Make sure registerNatives is the first thing <clinit> does. */

--- a/src/java.base/share/classes/java/lang/ThreadLocal.java
+++ b/src/java.base/share/classes/java/lang/ThreadLocal.java
@@ -73,6 +73,7 @@ import java.util.function.Supplier;
  * @author  Josh Bloch and Doug Lea
  * @since   1.2
  */
+/* TODO(b/170313595): @jdk.internal.vm.annotation.Preserve(false) */
 public class ThreadLocal<T> {
     /**
      * ThreadLocals rely on per-thread linear-probe hash maps attached

--- a/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -437,6 +437,7 @@ import static java.lang.invoke.MethodHandleStatics.newInternalError;
  * @see MethodType
  * @since 9
  */
+@jdk.internal.vm.annotation.Preserve(false)
 public abstract class VarHandle {
     final VarForm vform;
 
@@ -1525,6 +1526,7 @@ public abstract class VarHandle {
     Object getAndBitwiseXorRelease(Object... args);
 
 
+    @jdk.internal.vm.annotation.Preserve
     enum AccessType {
         GET(Object.class),
         SET(void.class),
@@ -1597,6 +1599,7 @@ public abstract class VarHandle {
      * The set of access modes that specify how a variable, referenced by a
      * VarHandle, is accessed.
      */
+    @jdk.internal.vm.annotation.Preserve(false)
     public enum AccessMode {
         /**
          * The access mode whose access is specified by the corresponding

--- a/src/java.base/share/classes/java/lang/module/Configuration.java
+++ b/src/java.base/share/classes/java/lang/module/Configuration.java
@@ -102,6 +102,7 @@ import jdk.internal.vm.annotation.Stable;
  * @spec JPMS
  * @see java.lang.ModuleLayer
  */
+@jdk.internal.vm.annotation.Preserve
 public final class Configuration {
 
     // @see Configuration#empty()
@@ -109,8 +110,15 @@ public final class Configuration {
     private static @Stable Configuration EMPTY_CONFIGURATION;
 
     static {
+        // GOOGLE: With the general support for class and static field
+        //         pre-initialization, it no longer needs to call
+        //         VM.initializeFromArchive() explicitly at runtime to
+        //         load the archived value for fields annotated with
+        //         @Preserve. That allows application classes to take
+        //         advantage of the pre-initialization feature.
+        //
         // Initialize EMPTY_CONFIGURATION from the archive.
-        VM.initializeFromArchive(Configuration.class);
+        //VM.initializeFromArchive(Configuration.class);
         // Create a new empty Configuration if there is no archived version.
         if (EMPTY_CONFIGURATION == null) {
             EMPTY_CONFIGURATION = new Configuration();

--- a/src/java.base/share/classes/java/net/URL.java
+++ b/src/java.base/share/classes/java/net/URL.java
@@ -150,6 +150,7 @@ import sun.security.action.GetPropertyAction;
  * @author  James Gosling
  * @since 1.0
  */
+@jdk.internal.vm.annotation.Preserve
 public final class URL implements java.io.Serializable {
 
     static final String BUILTIN_HANDLERS_PREFIX = "sun.net.www.protocol";
@@ -1244,6 +1245,7 @@ public final class URL implements java.io.Serializable {
 
     private static final URLStreamHandlerFactory defaultFactory = new DefaultFactory();
 
+    @jdk.internal.vm.annotation.Preserve
     private static class DefaultFactory implements URLStreamHandlerFactory {
         private static String PREFIX = "sun.net.www.protocol";
 

--- a/src/java.base/share/classes/java/nio/file/StandardOpenOption.java
+++ b/src/java.base/share/classes/java/nio/file/StandardOpenOption.java
@@ -31,6 +31,7 @@ package java.nio.file;
  * @since 1.7
  */
 
+@jdk.internal.vm.annotation.Preserve
 public enum StandardOpenOption implements OpenOption {
     /**
      * Open for read access.

--- a/src/java.base/share/classes/java/util/ImmutableCollections.java
+++ b/src/java.base/share/classes/java/util/ImmutableCollections.java
@@ -46,6 +46,7 @@ import jdk.internal.vm.annotation.Stable;
  * Serial warnings are suppressed throughout because all implementation
  * classes use a serial proxy and thus have no need to declare serialVersionUID.
  */
+@jdk.internal.vm.annotation.Preserve(false)
 @SuppressWarnings("serial")
 class ImmutableCollections {
     /**
@@ -71,6 +72,7 @@ class ImmutableCollections {
 
     static UnsupportedOperationException uoe() { return new UnsupportedOperationException(); }
 
+    @jdk.internal.vm.annotation.Preserve
     static abstract class AbstractImmutableCollection<E> extends AbstractCollection<E> {
         // all mutating methods throw UnsupportedOperationException
         @Override public boolean add(E e) { throw uoe(); }
@@ -99,6 +101,7 @@ class ImmutableCollections {
         return (List<E>) ListN.EMPTY_LIST;
     }
 
+    @jdk.internal.vm.annotation.Preserve
     static abstract class AbstractImmutableList<E> extends AbstractImmutableCollection<E>
             implements List<E>, RandomAccess {
 
@@ -407,6 +410,7 @@ class ImmutableCollections {
 
     }
 
+    @jdk.internal.vm.annotation.Preserve
     static final class ListN<E> extends AbstractImmutableList<E>
             implements Serializable {
 
@@ -414,7 +418,12 @@ class ImmutableCollections {
         static @Stable List<?> EMPTY_LIST;
 
         static {
-            VM.initializeFromArchive(ListN.class);
+            // GOOGLE: With the general support for class and static field
+            //         pre-initialization, it no longer needs to call
+            //         VM.initializeFromArchive() explicitly at runtime to
+            //         load the archived value for fields.
+            //
+            //VM.initializeFromArchive(ListN.class);
             if (EMPTY_LIST == null) {
                 EMPTY_LIST = new ListN<>();
             }
@@ -492,6 +501,7 @@ class ImmutableCollections {
         return (Set<E>) SetN.EMPTY_SET;
     }
 
+    @jdk.internal.vm.annotation.Preserve
     static final class Set12<E> extends AbstractImmutableSet<E>
             implements Serializable {
 
@@ -573,6 +583,7 @@ class ImmutableCollections {
      * least one null is always present.
      * @param <E> the element type
      */
+    @jdk.internal.vm.annotation.Preserve
     static final class SetN<E> extends AbstractImmutableSet<E>
             implements Serializable {
 
@@ -580,7 +591,12 @@ class ImmutableCollections {
         static @Stable Set<?> EMPTY_SET;
 
         static {
-            VM.initializeFromArchive(SetN.class);
+            // GOOGLE: With the general support for class and static field
+            //         pre-initialization, it no longer needs to call
+            //         VM.initializeFromArchive() explicitly at runtime to
+            //         load the archived value for fields.
+            //
+            //VM.initializeFromArchive(SetN.class);
             if (EMPTY_SET == null) {
                 EMPTY_SET = new SetN<>();
             }
@@ -792,13 +808,19 @@ class ImmutableCollections {
      * @param <K> the key type
      * @param <V> the value type
      */
+    @jdk.internal.vm.annotation.Preserve
     static final class MapN<K,V> extends AbstractImmutableMap<K,V> {
 
         // EMPTY_MAP may be initialized from the CDS archive.
         static @Stable Map<?,?> EMPTY_MAP;
 
         static {
-            VM.initializeFromArchive(MapN.class);
+            // GOOGLE: With the general support for class and static field
+            //         pre-initialization, it no longer needs to call
+            //         VM.initializeFromArchive() explicitly at runtime to
+            //         load the archived value for fields.
+            //
+            //VM.initializeFromArchive(MapN.class);
             if (EMPTY_MAP == null) {
                 EMPTY_MAP = new MapN<>();
             }

--- a/src/java.base/share/classes/java/util/Random.java
+++ b/src/java.base/share/classes/java/util/Random.java
@@ -73,6 +73,7 @@ import jdk.internal.misc.Unsafe;
  * @author  Frank Yellin
  * @since   1.0
  */
+/* TODO(b/170313595): @jdk.internal.vm.annotation.Preserve(false) */
 public
 class Random implements java.io.Serializable {
     /** use serialVersionUID from JDK 1.1 for interoperability */

--- a/src/java.base/share/classes/jdk/internal/misc/SharedSecrets.java
+++ b/src/java.base/share/classes/jdk/internal/misc/SharedSecrets.java
@@ -50,6 +50,7 @@ import java.security.Signature;
 public class SharedSecrets {
     private static final Unsafe unsafe = Unsafe.getUnsafe();
     private static JavaUtilJarAccess javaUtilJarAccess;
+    @jdk.internal.vm.annotation.Preserve
     private static JavaLangAccess javaLangAccess;
     private static JavaLangModuleAccess javaLangModuleAccess;
     private static JavaLangInvokeAccess javaLangInvokeAccess;
@@ -58,10 +59,14 @@ public class SharedSecrets {
     private static JavaNetInetAddressAccess javaNetInetAddressAccess;
     private static JavaNetHttpCookieAccess javaNetHttpCookieAccess;
     private static JavaNetSocketAccess javaNetSocketAccess;
+    @jdk.internal.vm.annotation.Preserve
     private static JavaNetUriAccess javaNetUriAccess;
+    @jdk.internal.vm.annotation.Preserve
     private static JavaNetURLAccess javaNetURLAccess;
     private static JavaNetURLClassLoaderAccess javaNetURLClassLoaderAccess;
+    @jdk.internal.vm.annotation.Preserve
     private static JavaNioAccess javaNioAccess;
+    @jdk.internal.vm.annotation.Preserve
     private static JavaIOFileDescriptorAccess javaIOFileDescriptorAccess;
     private static JavaIOFilePermissionAccess javaIOFilePermissionAccess;
     private static JavaSecurityAccess javaSecurityAccess;
@@ -76,6 +81,11 @@ public class SharedSecrets {
     private static JavaIORandomAccessFileAccess javaIORandomAccessFileAccess;
     private static JavaSecuritySignatureAccess javaSecuritySignatureAccess;
     private static JavaxCryptoSealedObjectAccess javaxCryptoSealedObjectAccess;
+
+    static {
+      unsafe.ensureClassInitialized(java.net.URI.class);
+      unsafe.ensureClassInitialized(java.net.URL.class);
+    }
 
     public static JavaUtilJarAccess javaUtilJarAccess() {
         if (javaUtilJarAccess == null) {

--- a/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -51,15 +51,21 @@ import java.security.ProtectionDomain;
  */
 
 public final class Unsafe {
+    @jdk.internal.vm.annotation.Stable
+    @jdk.internal.vm.annotation.Preserve
+    private static Unsafe theUnsafe;
 
     private static native void registerNatives();
     static {
         registerNatives();
+
+        // Load and use the archived value if it exists
+        if (theUnsafe == null) {
+            theUnsafe = new Unsafe();
+        }
     }
 
     private Unsafe() {}
-
-    private static final Unsafe theUnsafe = new Unsafe();
 
     /**
      * Provides the caller with the capability of performing unsafe

--- a/src/java.base/share/classes/jdk/internal/misc/VM.java
+++ b/src/java.base/share/classes/jdk/internal/misc/VM.java
@@ -29,6 +29,7 @@ import static java.lang.Thread.State.*;
 import java.util.Map;
 import java.util.Properties;
 
+@jdk.internal.vm.annotation.Preserve(false)
 public class VM {
 
     // the init level when the VM is fully initialized

--- a/src/java.base/share/classes/jdk/internal/module/ArchivedModuleGraph.java
+++ b/src/java.base/share/classes/jdk/internal/module/ArchivedModuleGraph.java
@@ -33,6 +33,7 @@ import jdk.internal.misc.VM;
 /**
  * Used by ModuleBootstrap to obtain the archived system modules and finder.
  */
+@jdk.internal.vm.annotation.Preserve
 final class ArchivedModuleGraph {
     private static String archivedMainModule;
     private static SystemModules archivedSystemModules;
@@ -92,6 +93,13 @@ final class ArchivedModuleGraph {
     }
 
     static {
-        VM.initializeFromArchive(ArchivedModuleGraph.class);
+        // GOOGLE: With the general support for class and static field
+        //         pre-initialization, it no longer needs to call
+        //         VM.initializeFromArchive() explicitly at runtime to
+        //         load the archived value for fields annotated with
+        //         @Preserve. That allows application classes to take
+        //         advantage of the pre-initialization feature.
+        //
+        //VM.initializeFromArchive(ArchivedModuleGraph.class);
     }
 }

--- a/src/java.base/share/classes/jdk/internal/module/ModuleBootstrap.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModuleBootstrap.java
@@ -1020,6 +1020,7 @@ public final class ModuleBootstrap {
     /**
      * Counters for startup performance analysis.
      */
+    @jdk.internal.vm.annotation.Preserve(false)
     static class Counters {
         private static final boolean PUBLISH_COUNTERS;
         private static final boolean PRINT_COUNTERS;

--- a/src/java.base/share/classes/jdk/internal/vm/annotation/Preserve.java
+++ b/src/java.base/share/classes/jdk/internal/vm/annotation/Preserve.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2020, Google, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.internal.vm.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * A class may be annotated for pre-initialization and preserving all its
+ * static field values in a CDS image with static archiving, if both of the
+ * following conditions hold:
+ * <ul>
+ * <li><p>The class' static initializer does not have any dependencies on
+ * the runtime context, such as using current date or time.
+ * <li><p>The class' static initializer does not manipulate any native states
+ * that are not archived, such as registering native methods or loading native
+ * libraries.
+ * </ul>
+ * <p>
+ * A pre-initialized class can bypass executing its static initializer and use
+ * archived static field values directly at runtime in subsequent executions
+ * where the archived data is used.
+ * <p>
+ * A class may be annotated explicitly with false to not pre-initialize and
+ * preserve its static fields in the archive:
+ * <pre>
+ *   &#064;jdk.internal.vm.annotation.Preserve(false)
+ * </pre>
+ * <p>
+ * A field may be annotated individually for pre-initializing and preserving
+ * its value in a CDS image with static archiving.
+ * <p>
+ * A class is in partially pre-initialized state if only some of its static
+ * fields are pre-initialized and preserved in the archive, and the rest of
+ * its static fields are not. The archived static field values can be loaded
+ * and accessed directly at runtime. The rest of the static fields in the class
+ * are initialized by executing related bytecode in the static initializer at
+ * runtime.
+ * <p>
+ * This is an example of how individually pre-initialized static field can be
+ * implemented to conditionally skipping related runtime bytecode execution:
+ * <hr><blockquote><pre>
+ *        @Preserve
+ *        static Integer[] archivedCache;
+ *
+ *        static {
+ *           int size = (high - low) + 1;
+ *
+ *           if (archivedCache == null || size > archivedCache.length) {
+ *               Integer[] c = new Integer[size];
+ *               int j = low;
+ *               for(int i = 0; i < c.length; i++) {
+ *                   c[i] = new Integer(j++);
+ *               }
+ *               archivedCache = c;
+ *           }
+ *        }
+ * </pre></blockquote><hr>
+ * <p>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Preserve {
+    /**
+     * Returns {@code true} if the initialized static fields can be preserved
+     * in the archive, {@code false} otherwise.
+     */
+    boolean value() default true;
+}

--- a/test/hotspot/jtreg/runtime/appcds/cacheObject/ArchivedIntegerCacheTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/cacheObject/ArchivedIntegerCacheTest.java
@@ -55,8 +55,11 @@ public class ArchivedIntegerCacheTest {
         //
         // Dump default archive
         //
+        // GOOGLE: Added java/lang/Short$ShortCache to the classlist as it may
+        //         not be in the default classlist.
         OutputAnalyzer output = TestCommon.dump(appJar,
-                TestCommon.list("CheckIntegerCacheApp"),
+                TestCommon.list("CheckIntegerCacheApp",
+                                "java/lang/Short$ShortCache"),
                 use_whitebox_jar);
         TestCommon.checkDump(output);
 
@@ -67,7 +70,7 @@ public class ArchivedIntegerCacheTest {
                 "-XX:+UnlockDiagnosticVMOptions",
                 "-XX:+WhiteBoxAPI",
                 "CheckIntegerCacheApp",
-                "127",
+                "3000",
                 "true");
         TestCommon.checkExec(output);
 
@@ -87,8 +90,11 @@ public class ArchivedIntegerCacheTest {
         //
         // Dump with -XX:AutoBoxCacheMax specified
         //
+        // GOOGLE: Added java/lang/Short$ShortCache to the classlist as it may
+        //         not be in the default classlist.
         output = TestCommon.dump(appJar,
-                TestCommon.list("CheckIntegerCacheApp"),
+                TestCommon.list("CheckIntegerCacheApp",
+                                "java/lang/Short$ShortCache"),
                 "-XX:AutoBoxCacheMax=20000",
                 use_whitebox_jar);
         TestCommon.checkDump(output);
@@ -103,7 +109,7 @@ public class ArchivedIntegerCacheTest {
                 "-XX:+UnlockDiagnosticVMOptions",
                 "-XX:+WhiteBoxAPI",
                 "CheckIntegerCacheApp",
-                "127",
+                "3000",
                 "true");
         TestCommon.checkExec(output);
 
@@ -140,8 +146,12 @@ public class ArchivedIntegerCacheTest {
 
         // Test case 6)
         // - Cache is too large to archive
+        //
+        // GOOGLE: Added java/lang/Short$ShortCache to the classlist as it may
+        //         not be in the default classlist.
         output = TestCommon.dump(appJar,
-                TestCommon.list("CheckIntegerCacheApp"),
+                TestCommon.list("CheckIntegerCacheApp",
+                                "java/lang/Short$ShortCache"),
                 "-XX:AutoBoxCacheMax=2000000",
                 "-Xmx1g",
                 "-XX:NewSize=1g",
@@ -149,8 +159,9 @@ public class ArchivedIntegerCacheTest {
                 "-Xlog:gc+region+cds",
                 "-Xlog:gc+region=trace",
                 use_whitebox_jar);
-        TestCommon.checkDump(output,
-            "Cannot archive the sub-graph referenced from [Ljava.lang.Integer; object",
-            "humongous regions have been found and may lead to fragmentation");
+        // GOOGLE: The following was updated to remove check for humongous
+        //         region as the default size for region is different in Google
+        //         JDK.
+        TestCommon.checkDump(output);
     }
 }

--- a/test/hotspot/jtreg/runtime/appcds/javaldr/HumongousDuringDump.java
+++ b/test/hotspot/jtreg/runtime/appcds/javaldr/HumongousDuringDump.java
@@ -68,12 +68,18 @@ public class HumongousDuringDump {
                               "-Xlog:gc+region+cds",
                               "-Xlog:gc+region=trace",
                               extraArg, "-Xmx64m", gcLog);
-        out.shouldContain("(Unmovable) humongous regions have been found and may lead to fragmentation");
-        out.shouldContain("All free regions should be at the top end of the heap, but we found holes.");
-        out.shouldMatch("gc,region,cds.*HeapRegion .* HUM. hole");
-        String pattern = "gc,region,cds.*HeapRegion .*hole";
-        out.shouldMatch(pattern);
-        out.shouldNotMatch(pattern + ".*unexpected");
+        // GOOGLE: The following checks are removed as
+        //         G1HeapVerifier::verify_ready_for_archiving() has been
+        //         disabled in Google JDK.
+        //         G1HeapVerifier::verify_ready_for_archiving() is not useful
+        //         and disabling it avoids wasting CPU cycles. Please see
+        //         heapShared.cpp for more details.
+        //out.shouldContain("(Unmovable) humongous regions have been found and may lead to fragmentation");
+        //out.shouldContain("All free regions should be at the top end of the heap, but we found holes.");
+        //out.shouldMatch("gc,region,cds.*HeapRegion .* HUM. hole");
+        //String pattern = "gc,region,cds.*HeapRegion .*hole";
+        //out.shouldMatch(pattern);
+        //out.shouldNotMatch(pattern + ".*unexpected");
 
         TestCommon.run(
                 "-cp", appJar,

--- a/test/hotspot/jtreg/runtime/appcds/preInit/ConcurrentInitTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/preInit/ConcurrentInitTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2020, Google Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test ConcurrentInitTest
+ * @summary Concurrently initialize some shared classes. No crash should occur.
+ * @requires vm.cds
+ * @library /test/lib /test/hotspot/jtreg/runtime/appcds
+ * @modules jdk.jartool/sun.tools.jar
+ * @build sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main/othervm ConcurrentInitTest
+ */
+
+import java.nio.ByteBuffer;
+import java.util.Formatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import jdk.test.lib.process.OutputAnalyzer;
+import sun.hotspot.WhiteBox;
+
+// This test simulates a case where multiple threads are trying to
+// intialize some shared classes at the same time and serves as a
+// regression test.
+//
+// The test creates a specified number of threads and tries to
+// trigger the class initialization for ByteBuffer and Formatter
+// simultaneously from different threads. The test should run to
+// completion without causing any crashes.
+public class ConcurrentInitTest {
+    static final int NUM_MIN_THREADS = 2;
+    static final int NUM_MAX_THREADS = 16;
+    public static void main(String[] args) throws Exception {
+        JarBuilder.build("concurrentInit",
+                         "ConcurrentInitTest",
+                         "ConcurrentInitTest$ConcurrentInitRunnable");
+
+        String appJar = TestCommon.getTestJar("concurrentInit.jar");
+        JarBuilder.build(true, "WhiteBox", "sun/hotspot/WhiteBox");
+        String whiteBoxJar = TestCommon.getTestJar("WhiteBox.jar");
+        String bootClassPath = "-Xbootclasspath/a:" + whiteBoxJar;
+
+        OutputAnalyzer dumpOutput = TestCommon.dump(appJar,
+                // ByteBuffer and Formatter should be already in the default
+                // classlist. Explicitly listing them here just to be sure.
+                TestCommon.list("java/nio/ByteBuffer",
+                                "java/util/Formatter",
+                                "ConcurrentInitTest",
+                                "ConcurrentInitTest$ConcurrentInitRunnable"),
+                bootClassPath);
+        TestCommon.checkDump(dumpOutput, "Loading classes to share");
+
+        int bound = NUM_MAX_THREADS - NUM_MIN_THREADS + 1;
+        int numThreads = (new Random()).nextInt(bound) + NUM_MIN_THREADS;
+        String[] classNames = {"java.nio.ByteBuffer",
+                               "java.util.Formatter"};
+        for (String s : classNames) {
+            System.out.println(
+                "Testing concurrently initializing " + s + " with " +
+                numThreads + " threads ...");
+            OutputAnalyzer execOutput = TestCommon.exec(
+                appJar, bootClassPath, "-XX:+UnlockDiagnosticVMOptions",
+                "-XX:+WhiteBoxAPI", "ConcurrentInitTest$ConcurrentInitRunnable",
+                Integer.toString(numThreads), s);
+            TestCommon.checkExec(execOutput, "OK");
+        }
+    }
+
+    static class ConcurrentInitRunnable implements Runnable {
+        static int numThreads;
+        static String className;
+
+        static Object lock = new Object();
+        static Class initializedClass;
+
+        String runnableName;
+
+        ConcurrentInitRunnable(String name) {
+            this.runnableName = name;
+        }
+
+        @Override
+        public void run() {
+            Class c;
+            // Multiple threads try to initialize the class at the same time.
+            try {
+                c = Class.forName(className, true, null);
+            } catch (ClassNotFoundException cnfe) {
+                throw new RuntimeException(
+                    className + " initialization failed");
+            }
+
+            synchronized(lock) {
+                if (initializedClass == null) {
+                    initializedClass = c;
+                    System.out.println(runnableName + " initialized " + className);
+                }
+            }
+        }
+
+        static void concurrentTest() {
+            List<Thread> threads = new ArrayList<Thread>();
+            for (int i = 0; i < numThreads; i++) {
+                threads.add(new Thread(
+                    new ConcurrentInitRunnable("ConcurrentInitRunnable_"+i)));
+            }
+
+            // Using a separate loop from above may help stress the concurrency.
+            for (Thread t1 : threads) {
+                t1.start();
+            }
+
+            for (Thread t2 : threads) {
+                try {
+                    t2.join();
+                } catch (InterruptedException ie) {
+                    throw new AssertionError(ie);
+                }
+            }
+        }
+
+        static void checkClass() {
+            WhiteBox wb = WhiteBox.getWhiteBox();
+            if (!wb.isSharedClass(initializedClass)) {
+                throw new RuntimeException(
+                    className + " is not shared");
+            }
+        }
+
+        // Test should complete successfully without any crashes.
+        public static void main(String[] args) {
+            numThreads = Integer.parseInt(args[0]);
+            className = args[1];
+
+            // Do concurrentTest() before checkClass(). This is to
+            // avoid unintentionally triggering the initialization of the
+            // class too early due to executing additional Java code.
+            concurrentTest();
+
+            // Now check if the class is a shared class.
+            checkClass();
+
+            System.out.println("OK");
+        }
+    }
+}

--- a/test/hotspot/jtreg/runtime/appcds/preInit/PreInitStatesBasicTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/preInit/PreInitStatesBasicTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2020, Google Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test PreInitStatesBasicTest
+ * @summary Test class pre-initialization states.
+ * @requires vm.cds
+ * @library /test/lib /test/hotspot/jtreg/runtime/appcds
+ * @modules jdk.jartool/sun.tools.jar
+ * @compile ../test-classes/Hello.java
+ * @run main/othervm PreInitStatesBasicTest
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class PreInitStatesBasicTest {
+
+    private static final String[] canPreserveStates = {
+        "Set can_preserve for class java.io.Serializable.*no <clinit> or static field",
+        "Set can_preserve for class java.lang.String.*with @Preserve annotation",
+        "Set can_preserve for class java.lang.Integer.*with @Preserve annotation",
+        "Set can_preserve for class java.lang.Long.*with @Preserve annotation",
+        "Set can_preserve for class java.io.OutputStream.*no <clinit> or static field",
+    };
+
+    private static final String[] preservableStates = {
+        "Add preservable class java.lang.String.*",
+        "Add preservable class java.io.Serializable.*",
+        "Add preservable class java.lang.Integer.*",
+        "Add preservable class java.lang.Long.*",
+        "Add preservable class java.io.OutputStream.*",
+    };
+
+    private static final String[] dumpTimePreInitStates = {
+        "Set java.io.Serializable to is_pre_initialized_without_dependency_class",
+        "Set java.lang.String to is_pre_initialized_with_dependency_class",
+        "Set java.util.Iterator to is_pre_initialized_without_dependency_class",
+    };
+
+    private static final String[] runtimePreInitStates = {
+        "initializing java.lang.String from archived subgraph",
+        "java.lang.String is fully pre-initialized",
+        "initializing java.lang.Integer\\$IntegerCache from archived subgraph",
+        "java.lang.Integer\\$IntegerCache.*is partially pre-initialized",
+    };
+
+    public static void main(String[] args) throws Exception {
+        String appJar = JarBuilder.getOrCreateHelloJar();
+
+        // Dump time tests
+        OutputAnalyzer dumpOutput = TestCommon.dump(
+                appJar, new String[] {"Hello"}, "-Xlog:preinit");
+        TestCommon.checkDump(dumpOutput, "Loading classes to share");
+
+        for (String canPreservePattern : canPreserveStates) {
+            dumpOutput.shouldMatch(canPreservePattern);
+        }
+
+        for (String preservablePattern : preservableStates) {
+            dumpOutput.shouldMatch(preservablePattern);
+        }
+
+        for (String dumpTimePreInitPattern : dumpTimePreInitStates) {
+            dumpOutput.shouldMatch(dumpTimePreInitPattern);
+        }
+
+        // Runtime tests
+        OutputAnalyzer execOutput = TestCommon.exec(appJar, "-Xlog:preinit", "Hello");
+        TestCommon.checkExec(execOutput, "Hello World");
+
+        for (String runtimePreInitPattern : runtimePreInitStates) {
+            execOutput.shouldMatch(runtimePreInitPattern);
+        }
+    }
+}

--- a/test/hotspot/jtreg/runtime/appcds/preInit/PreserveEnumTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/preInit/PreserveEnumTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2020, Google Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test PreserveEnumTest
+ * @summary Enum annotated using Preserve is fully pre-initialized.
+ * @requires vm.cds
+ * @library /test/lib /test/hotspot/jtreg/runtime/appcds
+ * @modules jdk.jartool/sun.tools.jar
+ * @build sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main/othervm PreserveEnumTest
+ */
+
+import java.nio.file.StandardOpenOption;
+import jdk.test.lib.process.OutputAnalyzer;
+import sun.hotspot.WhiteBox;
+
+public class PreserveEnumTest {
+    public static void main(String[] args) throws Exception {
+        JarBuilder.build("preserveEnum",
+                         "PreserveEnumTest",
+                         "PreserveEnumTest$PreserveEnumApp");
+
+        String appJar = TestCommon.getTestJar("preserveEnum.jar");
+        JarBuilder.build(true, "WhiteBox", "sun/hotspot/WhiteBox");
+        String whiteBoxJar = TestCommon.getTestJar("WhiteBox.jar");
+        String bootClassPath = "-Xbootclasspath/a:" + whiteBoxJar;
+
+        OutputAnalyzer dumpOutput = TestCommon.dump(appJar,
+                TestCommon.list("PreserveEnumTest",
+                                "PreserveEnumTest$PreserveEnumApp"),
+                "-Xlog:cds+heap=trace,preinit",
+                bootClassPath);
+        TestCommon.checkDump(dumpOutput, "Loading classes to share");
+
+        OutputAnalyzer execOutput = TestCommon.exec(appJar,
+            "-Xlog:preinit", bootClassPath,
+            "-XX:+UnlockDiagnosticVMOptions", "-XX:+WhiteBoxAPI",
+            "PreserveEnumTest$PreserveEnumApp");
+        TestCommon.checkExec(execOutput, "OK");
+    }
+
+    static class PreserveEnumApp {
+        public static void main(String[] args) {
+            WhiteBox wb = WhiteBox.getWhiteBox();
+            // StandardOpenOption is an enum type and is pre-initialized at
+            // dump time. The constants defined in StandardOpenOption are
+            // pre-populated and archived in the Java heap (shared Java
+            // objects) at dump time. Those objects are memory mapped into
+            // the runtime Java heap and can be used by the JVM directly once
+            // 'materialized' without recreating them by executing related
+            // Java code. Test if all constants in StandardOpenOption are
+            // shared objects at runtime.
+            for (StandardOpenOption p : StandardOpenOption.values()) {
+                if (!wb.isShared(p)) {
+                    throw new RuntimeException(
+                        "StandardOpenOption." + p + " is not shared");
+                }
+            }
+            System.out.println("OK");
+        }
+    }
+}

--- a/test/hotspot/jtreg/runtime/appcds/preInit/PreserveFalseTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/preInit/PreserveFalseTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2020, Google Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test PreserveFalseTest
+ * @summary Classes annotated with Preserve(false) must not be pre-initialized.
+ * @requires vm.cds
+ * @library /test/lib /test/hotspot/jtreg/runtime/appcds
+ * @modules jdk.jartool/sun.tools.jar
+ * @compile ../test-classes/Hello.java
+ * @run main/othervm PreserveFalseTest
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class PreserveFalseTest {
+
+    private static final String[] notPreInitializedClasses = {
+        "java.lang.Object",
+        "java.lang.Class",
+        "java.lang.ClassLoader",
+        "java.lang.System",
+        "java.lang.Thread",
+        "java.lang.ThreadLocal",
+        "java.util.ImmutableCollections",
+        "jdk.internal.module.ModuleBootstrap",
+        "jdk.internal.misc.VM",
+    };
+
+    public static void main(String[] args) throws Exception {
+        String appJar = JarBuilder.getOrCreateHelloJar();
+
+        OutputAnalyzer dumpOutput = TestCommon.dump(
+                appJar, new String[] {"Hello"});
+        TestCommon.checkDump(dumpOutput, "Loading classes to share");
+
+        OutputAnalyzer execOutput = TestCommon.exec(appJar, "-Xlog:preinit", "Hello");
+        TestCommon.checkExec(execOutput, "Hello World");
+
+        for (String p : notPreInitializedClasses) {
+            execOutput.shouldMatch(p + " is not pre-initialized");
+        }
+    }
+}

--- a/test/hotspot/jtreg/runtime/appcds/preInit/PreserveStaticFieldTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/preInit/PreserveStaticFieldTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2020, Google Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test PreserveStaticFieldTest
+ * @summary Class with static field annotated using Preserve is partially pre-initialized.
+ * @requires vm.cds
+ * @library /test/lib /test/hotspot/jtreg/runtime/appcds
+ * @modules jdk.jartool/sun.tools.jar
+ *          java.base/jdk.internal.misc
+ * @build sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main/othervm PreserveStaticFieldTest
+ */
+
+import jdk.internal.misc.JavaNetURLAccess;
+import jdk.internal.misc.SharedSecrets;
+import jdk.test.lib.process.OutputAnalyzer;
+import sun.hotspot.WhiteBox;
+
+public class PreserveStaticFieldTest {
+
+    private static final String[] preservedStaticFields = {
+        "Found @Preserve annotated field jdk/internal/misc/Unsafe.theUnsafe",
+        "Found @Preserve annotated field jdk/internal/misc/SharedSecrets.javaNetURLAccess",
+        "Archived field jdk/internal/misc/Unsafe::theUnsafe",
+        "Archived field jdk/internal/misc/SharedSecrets::javaNetURLAccess",
+    };
+
+    private static final String[] partialPreInitializedClasses = {
+        "jdk.internal.misc.Unsafe.*is partially pre-initialized",
+        "jdk.internal.misc.SharedSecrets.*is partially pre-initialized",
+    };
+
+    public static void main(String[] args) throws Exception {
+        JarBuilder.build("preserveStaticField",
+                         "PreserveStaticFieldTest",
+                         "PreserveStaticFieldTest$PreserveStaticFieldApp");
+
+        String appJar = TestCommon.getTestJar("preserveStaticField.jar");
+        JarBuilder.build(true, "WhiteBox", "sun/hotspot/WhiteBox");
+        String whiteBoxJar = TestCommon.getTestJar("WhiteBox.jar");
+        String bootClassPath = "-Xbootclasspath/a:" + whiteBoxJar;
+
+        OutputAnalyzer dumpOutput = TestCommon.dump(appJar,
+                TestCommon.list("PreserveStaticFieldTest",
+                                "PreserveStaticFieldTest$PreserveStaticFieldApp"),
+                "-Xlog:cds+heap=trace,preinit",
+                bootClassPath);
+        TestCommon.checkDump(dumpOutput, "Loading classes to share");
+
+        for (String f : preservedStaticFields) {
+            dumpOutput.shouldMatch(f);
+        }
+
+        OutputAnalyzer execOutput = TestCommon.exec(appJar,
+            "-Xlog:preinit", bootClassPath,
+            "-XX:+UnlockDiagnosticVMOptions", "-XX:+WhiteBoxAPI",
+            "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
+            "PreserveStaticFieldTest$PreserveStaticFieldApp");
+        TestCommon.checkExec(execOutput, "OK");
+
+        for (String c : partialPreInitializedClasses) {
+            execOutput.shouldMatch(c);
+        }
+    }
+
+    static class PreserveStaticFieldApp {
+        public static void main(String[] args) {
+            JavaNetURLAccess jnua = SharedSecrets.getJavaNetURLAccess();
+            WhiteBox wb = WhiteBox.getWhiteBox();
+            if (wb.isShared(jnua)) {
+                System.out.println("OK");
+            } else {
+                throw new RuntimeException(
+                    "object from SharedSecrets.getJavaNetURLAccess() is not shared");
+            }
+        }
+    }
+}


### PR DESCRIPTION
This patch implements the class pre-initialization support described in the design doc (http://cr.openjdk.java.net/~jiangli/Leyden/Java%20Class%20Pre-resolution%20and%20Pre-initialization%20(OpenJDK).pdf). It replaces the existing approach in Hotspot JVM that uses a list of hard-coded class names and static field names in JVM code (see https://github.com/openjdk/jdk11u/blob/master/src/hotspot/share/memory/heapShared.cpp) for pre-initialization.

This also moves away from the approach that requires Java code to call jdk.internal.misc.VM.initializeFromArchive() to explicitly 'install' (materialize) static field values from the archive at runtime. The new enhanced pre-initialization support will enable the usages in application classes.

An example of class pre-initialization in JDK:

[Before the general support]:

AbstractImmutableList.EMPTY_LIST must be 'registered' with JVM with an entry in 'open_archive_subgraph_entry_fields' list in heapShared.cpp.

    static final class ListN<E> extends AbstractImmutableList<E>
            implements Serializable {

        // EMPTY_LIST may be initialized from the CDS archive.
        static @Stable List<?> EMPTY_LIST;

        static {
            VM.initializeFromArchive(ListN.class);
            if (EMPTY_LIST == null) {
                EMPTY_LIST = new ListN<>();
            }
        }

[With the general support]:

    @jdk.internal.vm.annotation.Preserve
    static final class ListN<E> extends AbstractImmutableList<E>
            implements Serializable {

        // EMPTY_LIST may be initialized from the CDS archive.
        static @Stable List<?> EMPTY_LIST;

        static {
            if (EMPTY_LIST == null) {
                EMPTY_LIST = new ListN<>();
            }
        }

Class pre-initialization design doc:
http://cr.openjdk.java.net/~jiangli/Leyden/Java%20Class%20Pre-resolution%20and%20Pre-initialization%20(OpenJDK).pdf

Class pre-initialization design review slides:
http://cr.openjdk.java.net/~jiangli/Leyden/Selectively%20Pre-initializing%20and%20Preserving%20Java%20Classes%20(OpenJDK).pdf

Classes annotated with @Preserve annotation are explicitly initialized at CDS image creation time. All static field values (if preservable) in the classes are archived in the image. Those classes are fully pre-initialized at CDS image creation time.

Classes with any static fields annotated with @Preserve are also explicitly initialized at CDS image creation time. The preservable static field values are archived in the image. The corresponding classes are considered as partially pre-initialized in the image.

For a preserved reference type static field, all reachable Java objects from the field value are preserved in the image. The class types of the reachable objects are the dependencies of the archived static field, and are recorded in the image. At runtime, the dependency classes are explicitly initialized before the current class with preserved static fields.

If a pre-initialized class has no dependency class, the class can be set to fully_initialized state when being loaded and restored from the archive, if:

-  The direct super class is j.l.Object, local interfaces are pre-initialized and have no dependency classes;
- All super classes (except j.l.Object) and super interfaces are pre-initialized and have no dependency classes;

Author: jianglizhou@google.com
Reviewed by: jonathanjoo@google.com, Martin Buchholz, rasbold@google.com

-----
Additional notes for merging with jdk11u-fast-startup-incubator:

- Some of the diffs in the following files were hand merged:
  - ./src/java.base/share/classes/jdk/internal/module/ArchivedModuleGraph.java
  - ./src/hotspot/share/oops/instanceKlass.cpp.rej
  - ./src/hotspot/share/classfile/classFileParser.cpp.rej
  - ./src/hotspot/share/memory/heapShared.cpp.rej

- Resolved a dump time crash due to merging issue.

- Resolved a runtime hang due to merging issue.