### PR TITLE
Extend preservable classes by given class list file

### DIFF
--- a/src/hotspot/share/classfile/symbolTable.cpp
+++ b/src/hotspot/share/classfile/symbolTable.cpp
@@ -72,13 +72,6 @@ bool SymbolTable::_needs_rehashing = false;
 bool SymbolTable::_lookup_shared_first = false;
 static juint murmur_seed = 0;
 
-// Pick hashing algorithm.
-static uintx hash_symbol(const char* s, int len, bool useAlt) {
-  return useAlt ?
-  AltHashing::halfsiphash_32(murmur_seed, (const uint8_t*)s, len) :
-  java_lang_String::hash_code((const jbyte*)s, len);
-}
-
 static uintx hash_shared_symbol(const char* s, int len) {
   return java_lang_String::hash_code((const jbyte*)s, len);
 }

--- a/src/hotspot/share/classfile/symbolTable.cpp
+++ b/src/hotspot/share/classfile/symbolTable.cpp
@@ -72,6 +72,15 @@ bool SymbolTable::_needs_rehashing = false;
 bool SymbolTable::_lookup_shared_first = false;
 static juint murmur_seed = 0;
 
+#ifdef ASSERT
+// Pick hashing algorithm.
+static uintx hash_symbol(const char* s, int len, bool useAlt) {
+  return useAlt ?
+  AltHashing::halfsiphash_32(murmur_seed, (const uint8_t*)s, len) :
+  java_lang_String::hash_code((const jbyte*)s, len);
+}
+#endif
+
 static uintx hash_shared_symbol(const char* s, int len) {
   return java_lang_String::hash_code((const jbyte*)s, len);
 }

--- a/src/hotspot/share/memory/heapShared.cpp
+++ b/src/hotspot/share/memory/heapShared.cpp
@@ -1135,7 +1135,6 @@ void HeapShared::initialize_preservable_klass_from_list(Thread* THREAD) {
                                    Handle()/*null_protection_domain*/, THREAD);
       if (k == NULL) {
         if (HAS_PENDING_EXCEPTION) {
-          CLEAR_PENDING_EXCEPTION;
 #ifndef PRODUCT
           if (Verbose) {
             Handle throwable(THREAD, PENDING_EXCEPTION);
@@ -1143,13 +1142,13 @@ void HeapShared::initialize_preservable_klass_from_list(Thread* THREAD) {
             tty->cr();
           }
 #endif
+          CLEAR_PENDING_EXCEPTION;
         }
         log_warning(preinit)("Failed to load klass %s", klass_name->as_C_string());
         continue;
       }
       if (k->is_instance_klass()) {
         InstanceKlass* ik = InstanceKlass::cast(k);
-        assert(ik->is_not_initialized(), "must be");
         HeapShared::set_can_preserve(ik, false);
         HeapShared::add_preservable_class(ik);
       }
@@ -1356,6 +1355,9 @@ public:
 void HeapShared::set_can_preserve(InstanceKlass *ik, bool is_annotated) {
   if (DumpSharedSpaces && PreInitializeArchivedClass &&
       _can_add_preserve_klasses) {
+    if (ik->can_preserve()) {
+      return;
+    }
     ik->set_can_preserve();
     ResourceMark rm;
     log_info(preinit)("Set can_preserve for class %s(" PTR_FORMAT "), %s",

--- a/src/hotspot/share/memory/heapShared.cpp
+++ b/src/hotspot/share/memory/heapShared.cpp
@@ -1134,16 +1134,6 @@ void HeapShared::initialize_preservable_klass_from_list(Thread* THREAD) {
                                    Handle(THREAD, SystemDictionary::java_system_loader()),
                                    Handle()/*null_protection_domain*/, THREAD);
       if (k == NULL) {
-        if (HAS_PENDING_EXCEPTION) {
-#ifndef PRODUCT
-          if (Verbose) {
-            Handle throwable(THREAD, PENDING_EXCEPTION);
-            java_lang_Throwable::print_stack_trace(throwable, tty);
-            tty->cr();
-          }
-#endif
-          CLEAR_PENDING_EXCEPTION;
-        }
         log_warning(preinit)("Failed to load klass %s", klass_name->as_C_string());
         continue;
       }

--- a/src/hotspot/share/memory/heapShared.cpp
+++ b/src/hotspot/share/memory/heapShared.cpp
@@ -1144,29 +1144,14 @@ void HeapShared::initialize_preservable_klass_from_list(Thread* THREAD) {
           }
 #endif
         }
-        log_warning(preinit)("Failed to preserve klass %s", klass_name->as_C_string());
+        log_warning(preinit)("Failed to load klass %s", klass_name->as_C_string());
         continue;
       }
       if (k->is_instance_klass()) {
         InstanceKlass* ik = InstanceKlass::cast(k);
-        ik->initialize(THREAD);
-        if (HAS_PENDING_EXCEPTION) {
-          CLEAR_PENDING_EXCEPTION;
-#ifndef PRODUCT
-          if (Verbose) {
-            Handle throwable(THREAD, PENDING_EXCEPTION);
-            java_lang_Throwable::print_stack_trace(throwable, tty);
-            tty->cr();
-          }
-#endif
-          log_warning(preinit)("Failed to preserve klass %s", klass_name->as_C_string());
-          continue;
-        } else {
-          assert(!ik->is_not_initialized(), "must be");
-          ik->constants()->resolve_class_constants(THREAD);
-          HeapShared::set_can_preserve(ik, false);
-          HeapShared::add_preservable_class(ik);
-        }
+        assert(ik->is_not_initialized(), "must be");
+        HeapShared::set_can_preserve(ik, false);
+        HeapShared::add_preservable_class(ik);
       }
     }
   }

--- a/src/hotspot/share/memory/heapShared.hpp
+++ b/src/hotspot/share/memory/heapShared.hpp
@@ -419,6 +419,7 @@ class HeapShared: AllStatic {
                                                     size_t oopmap_in_bits) NOT_CDS_JAVA_HEAP_RETURN;
 
   static void initialize_subgraph_entry_fields(Thread* THREAD) NOT_CDS_JAVA_HEAP_RETURN;
+  static void initialize_preservable_klass_from_list(Thread* THREAD) NOT_CDS_JAVA_HEAP_RETURN;
   static void write_subgraph_info_table() NOT_CDS_JAVA_HEAP_RETURN;
   static void serialize_subgraph_info_table_header(SerializeClosure* soc) NOT_CDS_JAVA_HEAP_RETURN;
 };

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2078,6 +2078,13 @@ bool Arguments::check_vm_args_consistency() {
   }
 #endif
 
+#ifdef INCLUDE_CDS
+  if (PreInitializeArchivedClassList && ((!RequireSharedSpaces && !DumpSharedSpaces) || !PreInitializeArchivedClass)) {
+    log_error(cds, heap)("AppCDS is required when using -XX:PreInitializeArchivedClassList option");
+    status = false;
+  }
+#endif
+
   if (!FLAG_IS_DEFAULT(AllocateHeapAt)) {
     if ((UseNUMAInterleaving && !FLAG_IS_DEFAULT(UseNUMAInterleaving)) || (UseNUMA && !FLAG_IS_DEFAULT(UseNUMA))) {
       log_warning(arguments) ("NUMA support for Heap depends on the file system when AllocateHeapAt option is used.\n");

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -2514,6 +2514,10 @@ define_pd_global(uint64_t,MaxRAM,                    1ULL*G);
           "Support pre-initializing and preserving selected classes and "   \
           "individual static fields during static CDS dump time.")          \
                                                                             \
+  product(ccstr, PreInitializeArchivedClassList, NULL,                      \
+          "Support pre-initializing and preserving classes from given "     \
+          "list during static CDS dump time.")                              \
+                                                                            \
   product(bool, PrintSharedArchiveAndExit, false,                           \
           "Print shared archive file contents")                             \
                                                                             \

--- a/src/hotspot/share/utilities/ostream.cpp
+++ b/src/hotspot/share/utilities/ostream.cpp
@@ -383,6 +383,7 @@ stringStream::~stringStream() {
 xmlStream*   xtty;
 outputStream* tty;
 CDS_ONLY(fileStream* classlist_file;) // Only dump the classes that can be stored into the CDS archive
+CDS_ONLY(fileStream* preinit_classlist_file;)
 extern Mutex* tty_lock;
 
 #define EXTRACHARLEN   32
@@ -551,8 +552,11 @@ long fileStream::fileSize() {
 
 char* fileStream::readln(char *data, int count ) {
   char * ret = ::fgets(data, count, _file);
-  //Get rid of annoying \n char
-  data[::strlen(data)-1] = '\0';
+  // Get rid of annoying \n char only if it is present.
+  size_t len = ::strlen(data);
+  if (len > 0 && data[len - 1] == '\n') {
+    data[len - 1] = '\0';
+  }
   return ret;
 }
 
@@ -911,6 +915,10 @@ void ostream_init_log() {
     classlist_file = new(ResourceObj::C_HEAP, mtInternal)
                          fileStream(list_name);
     FREE_C_HEAP_ARRAY(char, list_name);
+  }
+  if (PreInitializeArchivedClassList != NULL) {
+    preinit_classlist_file = new(ResourceObj::C_HEAP, mtInternal)
+                                 fileStream(PreInitializeArchivedClassList, "r");
   }
 #endif
 

--- a/src/hotspot/share/utilities/ostream.hpp
+++ b/src/hotspot/share/utilities/ostream.hpp
@@ -240,6 +240,7 @@ class fileStream : public outputStream {
 };
 
 CDS_ONLY(extern fileStream*   classlist_file;)
+CDS_ONLY(extern fileStream*   preinit_classlist_file;)
 
 // unlike fileStream, fdStream does unbuffered I/O by calling
 // open() and write() directly. It is async-safe, but output

--- a/test/hotspot/jtreg/runtime/appcds/preInit/PreserveClassFromListTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/preInit/PreserveClassFromListTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2022 Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation. Alibaba designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+/*
+ * @test PreserveClassFromListTest
+ * @summary Pre-initialize classes from given class list file
+ * @requires vm.cds
+ * @library /test/lib /test/hotspot/jtreg/runtime/appcds
+ * @modules jdk.jartool/sun.tools.jar
+ *          java.base/jdk.internal.misc
+ * @build sun.hotspot.WhiteBox
+ * @run driver ClassFileInstaller sun.hotspot.WhiteBox
+ * @run main/othervm PreserveClassFromListTest
+ */
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import jdk.internal.misc.JavaNetURLAccess;
+import jdk.internal.misc.SharedSecrets;
+import jdk.test.lib.process.OutputAnalyzer;
+import sun.hotspot.WhiteBox;
+
+public class PreserveClassFromListTest {
+
+    private static final String[] dumpContent = {
+        "Add preservable class PreserveClassFromListTest\\$PreserveStaticFieldApp",
+        "Archived object klass PreserveClassFromListTest\\$PreserveStaticFieldApp.*=> java.util.HashMap"
+    };
+    private static final String[] runContent = {
+        "initializing PreserveClassFromListTest\\$PreserveStaticFieldApp from archived subgraph",
+        "PreserveClassFromListTest\\$PreserveStaticFieldApp is fully pre-initialized"
+    };
+
+    public static void main(String[] args) throws Exception {
+        JarBuilder.build("preserveClassFromList",
+                         "PreserveClassFromListTest",
+                         "PreserveClassFromListTest$PreserveStaticFieldApp");
+
+        String appJar = TestCommon.getTestJar("preserveClassFromList.jar");
+        Path filePath = Path.of("preservable.list");
+        try {
+            Files.writeString(filePath, "PreserveClassFromListTest$PreserveStaticFieldApp");
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        OutputAnalyzer dumpOutput = TestCommon.dump(appJar,
+                TestCommon.list("PreserveClassFromListTest",
+                                "PreserveClassFromListTest$PreserveStaticFieldApp"),
+                "-Xlog:cds+heap=trace,preinit",
+                "-XX:PreInitializeArchivedClassList=" + filePath.toAbsolutePath().toString());
+        TestCommon.checkDump(dumpOutput, "Loading classes to share");
+        for (String f : dumpContent) {
+            dumpOutput.shouldMatch(f);
+        }
+
+        OutputAnalyzer execOutput = TestCommon.exec(appJar,
+            "-Xlog:preinit",
+            "PreserveClassFromListTest$PreserveStaticFieldApp");
+        TestCommon.checkExec(execOutput, "42");
+        TestCommon.checkExec(execOutput, "1001");
+        TestCommon.checkExec(execOutput, "B");
+        for (String f : runContent) {
+            execOutput.shouldMatch(f);
+        }
+    }
+
+    static class PreserveStaticFieldApp {
+        private static Map<Integer, Integer> map = new HashMap<>();
+
+        private static char ch = 'B';
+
+        static {
+            for (int i = 0; i < 1024; i++) {
+                map.put(i, i);
+            }
+        }
+        public static void main(String[] args) {
+            System.out.println(map.get(42));
+            System.out.println(map.get(1001));
+            System.out.println(ch);
+        }
+    }
+}

--- a/test/hotspot/jtreg/runtime/appcds/preInit/PreserveClassFromListTest.java
+++ b/test/hotspot/jtreg/runtime/appcds/preInit/PreserveClassFromListTest.java
@@ -62,7 +62,7 @@ public class PreserveClassFromListTest {
         String appJar = TestCommon.getTestJar("preserveClassFromList.jar");
         Path filePath = Path.of("preservable.list");
         try {
-            Files.writeString(filePath, "PreserveClassFromListTest$PreserveStaticFieldApp");
+            Files.writeString(filePath, "PreserveClassFromListTest$PreserveStaticFieldApp\nInvalidClass");
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -73,6 +73,7 @@ public class PreserveClassFromListTest {
                 "-Xlog:cds+heap=trace,preinit",
                 "-XX:PreInitializeArchivedClassList=" + filePath.toAbsolutePath().toString());
         TestCommon.checkDump(dumpOutput, "Loading classes to share");
+        TestCommon.checkDump(dumpOutput, "Failed to load klass InvalidClass");
         for (String f : dumpContent) {
             dumpOutput.shouldMatch(f);
         }


### PR DESCRIPTION
Add -XX:PreInitializeArchivedClassListExtend=test.log to extend preservable classes by given class list file test.log, its content format looks as well as DumpLoadedClassList:
```
com/package/Foo
com/package/Bar
```

This flag can be used to test the robustness of the pre-initialization mechanism by allowing archiving more static fields of the class. Also, it can be used by some pre-initialization static analysis tools, which produces a list of class that guaranteed to be safe for pre-initialization.